### PR TITLE
docs: expand global development strategy 

### DIFF
--- a/Analyse/development_strategy.md
+++ b/Analyse/development_strategy.md
@@ -3,6 +3,40 @@
 ## Overview
 This document outlines the development standards and practices for the Paddle Sites Management web application. Following these guidelines ensures code quality, maintainability, and effective collaboration. 
 
+## Global development strategy
+
+### Big picture
+
+From the client needs, evaluate the big features and pages that has to be developed. The development will be organized page by page. So development order should be established. The next 2 pages should be deepen annalysed.
+
+### Analyse
+
+Once the order has been set, a more exhaustive analyse has to be made. 
+For each pages, a new md file should be created with the name of the page. In this file, there must be a table containing user stories. The user stories should follow this format: 
+| role        | condition             | action               | benefit                      |
+|-------------|-----------------------|----------------------|------------------------------|
+| As a [role] | (potential condition) | I can [do something] | So that I [get some benefit] |
+
+### Frontend-First Development
+The initial development phase will focus on **Angular frontend development** to: 
+- Visualize and validate user workflows
+- Define and prioritize features based on UI requirements
+- Identify the underlying data structures needed
+- Establish data formats and interfaces early
+- Create a foundation for backend API specifications
+
+This approach ensures that: 
+1. UI/UX can be tested and refined early
+2. Data requirements are clearly defined before backend development
+3. API contracts are established through TypeScript interfaces
+4. Backend development can follow TDD with clear requirements
+
+
+### Resposiveness
+
+To ensure responsivness and optimal performances on smaller screens, adopt the mobile first approach:
+Develop a feature for mobile size device and then adapt the display for larger screens.
+
 ## Code Quality Standards
 
 ### SOLID Principles


### PR DESCRIPTION
This pull request updates the development strategy documentation for the Paddle Sites Management web application. The main focus is on clarifying the overall development approach, emphasizing a frontend-first methodology, and outlining the process for analyzing and documenting features.

Development process and strategy updates:

* Expanded the strategy section to include a "Global development strategy" with a step-by-step process: high-level feature planning, detailed analysis per page, and documentation of user stories in dedicated markdown files.
* Introduced a "Frontend-First Development" approach, prioritizing Angular frontend work to define workflows, data needs, and API contracts before backend development.
* Added guidance for a "mobile first" approach to ensure responsiveness and performance on smaller screens.

Documentation structure:

* Renamed the file from `Analyse/code_strategy.md` to `Analyse/development_strategy.md` to better reflect the broader scope of the content.