### PR TITLE
add user stories for site list page

### DIFF
--- a/Documents/Analyse/pages/site-list-page.md
+++ b/Documents/Analyse/pages/site-list-page.md
@@ -1,0 +1,15 @@
+## User stories
+
+| role | condition | action | benefit |
+|------|-----------|--------|---------|
+| global admin | | consult the list of sites | see all the sites including their names, number of courts and Company revenue |
+| global admin | | change the order of listing | order by either name, courts number or revenue |
+| global admin | | filter on name | see only sites that match the input |
+| global admin | | filter on revenue | see only sites that are more or less than the input |
+|      |           |        |         |
+|      |           |        |         |
+|      |           |        |         |
+|      |           |        |         |
+|      |           |        |         |
+
+nb: since role and authentication are not yet implemented, any user can access the sites list.


### PR DESCRIPTION
This pull request adds user stories to the `site-list-page` documentation to clarify the intended functionality and benefits for users. The stories focus on the actions a global admin can take regarding the site list and the expected outcomes.

Documentation updates:

* Added a user story table to `Documents/Analyse/pages/site-list-page.md`, outlining global admin capabilities such as viewing, ordering, and filtering the list of sites, along with the associated benefits.
* Included a note specifying that, since authentication is not implemented yet, any user can currently access the site list.