### PR TITLE
13 generic pagination component

### DIFF
--- a/ProjetWeb.Frontend/Frontend/src/app/app.routes.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { PaginationDemoComponent } from './views/pages/pagination-demo/pagination-demo.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: PaginationDemoComponent }
+];

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.css
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.css
@@ -1,0 +1,29 @@
+.demo {
+  padding: 1rem;
+}
+
+.list {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.list.loading {
+  opacity: 0.6;
+}
+
+.item {
+  display: flex;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #eee;
+}
+
+.item:last-child {
+  border-bottom: 0;
+}
+
+.id {
+  width: 4rem;
+  font-weight: 600;
+}

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.html
@@ -1,7 +1,7 @@
 <section class="demo">
   <h2>Pagination demo (client-simulated server paging)</h2>
 
-  <div class="list" [class.loading]="loading">
+  <div class="list" [class.loading]="loading()">
     <div class="item" *ngFor="let item of (page$ | async)?.items">
       <span class="id">{{ item.id }}</span>
       <span class="name">{{ item.name }}</span>
@@ -12,7 +12,7 @@
     [totalItems]="(page$ | async)?.totalItems ?? 0"
     [pageIndex]="(request$ | async)?.pageIndex ?? 0"
     [pageSize]="(request$ | async)?.pageSize ?? 10"
-    [loading]="loading"
+    [loading]="loading()"
     (pageChange)="onPageChange($event)"
   />
 </section>

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.html
@@ -1,0 +1,18 @@
+<section class="demo">
+  <h2>Pagination demo (client-simulated server paging)</h2>
+
+  <div class="list" [class.loading]="loading">
+    <div class="item" *ngFor="let item of (page$ | async)?.items">
+      <span class="id">{{ item.id }}</span>
+      <span class="name">{{ item.name }}</span>
+    </div>
+  </div>
+
+  <app-pagination
+    [totalItems]="(page$ | async)?.totalItems ?? 0"
+    [pageIndex]="(request$ | async)?.pageIndex ?? 0"
+    [pageSize]="(request$ | async)?.pageSize ?? 10"
+    [loading]="loading"
+    (pageChange)="onPageChange($event)"
+  />
+</section>

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.ts
@@ -1,0 +1,71 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { PaginationComponent } from '../../shared/components/pagination/pagination.component';
+import {PageRequest, PageResponse} from '../../shared/types/paging';
+import {
+  BehaviorSubject,
+  catchError,
+  distinctUntilChanged,
+  finalize,
+  Observable,
+  of,
+  shareReplay,
+  switchMap,
+  tap
+} from 'rxjs';
+type Item = { id: number; name: string };
+
+@Component({
+  selector: 'app-pagination-demo',
+  standalone: true,
+  imports: [CommonModule, PaginationComponent],
+  templateUrl: './pagination-demo.component.html',
+  styleUrl: './pagination-demo.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PaginationDemoComponent {
+  loading = signal(false);
+
+  all: Item[] = Array.from({ length: 137 }, (_, i) => ({ id: i + 1, name: `Item ${i + 1}` }));
+
+
+  private readonly requestSubject = new BehaviorSubject<PageRequest>({ pageIndex: 0, pageSize: 10 });
+  readonly request$ = this.requestSubject.asObservable();
+
+  // Replace with real HttpClient call in a service.
+  private fetchPage(req: PageRequest): Observable<PageResponse<Item>> {
+    const start = req.pageIndex * req.pageSize;
+    const items = this.all.slice(start, start + req.pageSize);
+
+    // Simulated latency:
+    return of({
+      items,
+      pageIndex: req.pageIndex,
+      pageSize: req.pageSize,
+      totalItems: this.all.length
+    });
+  }
+
+  readonly page$ = this.request$.pipe(
+    distinctUntilChanged((a, b) => a.pageIndex === b.pageIndex && a.pageSize === b.pageSize),
+    tap(() => (this.loading.set(true))),
+    switchMap((req) =>
+      this.fetchPage(req).pipe(
+        catchError(() =>
+          of({
+            items: [],
+            pageIndex: req.pageIndex,
+            pageSize: req.pageSize,
+            totalItems: 0
+          })
+        ),
+        finalize(() => (this.loading.set(false)))
+      )
+    ),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  onPageChange(req: PageRequest): void {
+    this.requestSubject.next(req);
+  }
+}

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.css
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.html
@@ -1,0 +1,10 @@
+<mat-paginator
+  [length]="totalItems"
+  [pageIndex]="pageIndex"
+  [pageSize]="pageSize"
+  [pageSizeOptions]="pageSizeOptions"
+  [hidePageSize]="hidePageSize"
+  [showFirstLastButtons]="showFirstLastButtons"
+  [disabled]="disabled || loading"
+  (page)="onPage($event)"
+></mat-paginator>

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { PageRequest } from '../../types/paging';
+
+@Component({
+  selector: 'app-pagination',
+  standalone: true,
+  imports: [CommonModule, MatPaginatorModule],
+  templateUrl: './pagination.component.html',
+  styleUrl: './pagination.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PaginationComponent {
+  /**
+   * Total number of items in the dataset.
+   * If null/undefined, the paginator will still work, but last-page behavior isn't available.
+   */
+  @Input({ required: false }) totalItems: number | null | undefined = 0;
+
+  /** 0-based index coming from the container */
+  @Input({ required: true }) pageIndex = 0;
+
+  /** page size coming from the container */
+  @Input({ required: true }) pageSize = 10;
+
+  @Input({ required: false }) pageSizeOptions: readonly number[] = [10, 25, 50];
+  @Input({ required: false }) disabled = false;
+  @Input({ required: false }) loading = false;
+  @Input({ required: false }) hidePageSize = false;
+  @Input({ required: false }) showFirstLastButtons = true;
+
+  @Output() pageChange = new EventEmitter<PageRequest>();
+
+
+  protected onPage(event: PageEvent): void {
+    if (this.disabled || this.loading) return;
+    const pageSizeChanged = event.pageSize !== this.pageSize;
+    const next: PageRequest = {
+      pageIndex: pageSizeChanged ? 0 : event.pageIndex,
+      pageSize: event.pageSize
+    };
+    this.pageChange.emit(next);
+  }
+}

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/types/paging.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/types/paging.ts
@@ -1,0 +1,20 @@
+
+/**
+ * Generic request shape for server-side paging.
+ * - pageIndex is 0-based
+ * - pageSize must be > 0
+ */
+export interface PageRequest {
+  pageIndex: number;
+  pageSize: number;
+}
+
+/**
+ * Generic response shape for server-side paged endpoints.
+ */
+export interface PageResponse<T> {
+  items: T[];
+  totalItems: number;
+  pageIndex: number;
+  pageSize: number;
+}


### PR DESCRIPTION
This pull request introduces a reusable, standalone pagination component and a demo page to showcase client-side simulated server paging in the Angular frontend. The main changes include implementing a generic pagination component, defining paging types, and adding a demo page with simulated data and loading states.

**Pagination component implementation:**

* Added a new `PaginationComponent` (`pagination.component.ts`, `pagination.component.html`, `pagination.component.css`) that wraps Angular Material's paginator and exposes a reusable API for total items, page index, page size, loading, and other options. It emits page change events with a generic `PageRequest` shape. [[1]](diffhunk://#diff-20afee7407a4e12db5cec625d1462b98abdf1ccafebac6dda4da87df32f95380R1-R45) [[2]](diffhunk://#diff-7ae3efb3dff76e8964251e8d4c0e3c87075b5b97c02d1670b6ebd148c418a0b6R1-R10) [[3]](diffhunk://#diff-f203ed7cb2a0ec6a78f6032b3c3d2a4cf7106dca1545bb31762ccf3a0a2387d5R1-R3)
* Defined generic paging types `PageRequest` and `PageResponse<T>` for use with paginated data throughout the app.

**Demo page and routing:**

* Created a new `PaginationDemoComponent` (`pagination-demo.component.ts`, `pagination-demo.component.html`, `pagination-demo.component.css`) that simulates server-side paging over a static array, handles loading states, and displays paginated items using the new pagination component. [[1]](diffhunk://#diff-2280441ea533973df90ab6209785a83f0644fad07189bf8339d188c66408f222R1-R71) [[2]](diffhunk://#diff-289990795b032f1c6dc16036904e46b2264ae82826e523c4ccebd04aa0db7ae0R1-R18) [[3]](diffhunk://#diff-3c480db23ea7e80fc656c1ae2a01b20499eedcfb0b26c64c204a265808b370a3R1-R29)
* Updated the root app routes to display the pagination demo at the root path.