### PR TITLE
feat(site-list): add site list page with pagination

### DIFF
--- a/ProjetWeb.Frontend/Frontend/src/app/app.routes.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Routes } from '@angular/router';
 import { PaginationDemoComponent } from './views/pages/pagination-demo/pagination-demo.component';
+import { SiteList } from "./views/pages/sites-list/components/site-list/site-list";
 
 export const routes: Routes = [
-  { path: '', component: PaginationDemoComponent }
+  { path: '', component: PaginationDemoComponent },
+  { path: 'sites', component: SiteList }
 ];

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/pagination-demo/pagination-demo.component.ts
@@ -17,7 +17,6 @@ type Item = { id: number; name: string };
 
 @Component({
   selector: 'app-pagination-demo',
-  standalone: true,
   imports: [CommonModule, PaginationComponent],
   templateUrl: './pagination-demo.component.html',
   styleUrl: './pagination-demo.component.css',

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
@@ -1,0 +1,46 @@
+<h2>list of all the paddel sites!</h2>
+
+<!--<div class="list" [class.loading]="loading()">-->
+<!--  <mat-list>-->
+<!--    @for (site of this.items$ | async; track site.id) {-->
+<!--      <mat-list-item>-->
+<!--        <span matListItemTitle>{{ site.name }}</span>-->
+<!--        <span matListItemLine>{{ site.courts.length }} courts</span>-->
+<!--      </mat-list-item>-->
+<!--    }-->
+<!--  </mat-list>-->
+<!--</div>-->
+
+<div class="list" [class.loading]="loading()">
+  <table mat-table [dataSource]="(items$ | async) ?? []" class="mat-elevation-z1">
+
+    <!-- Name column -->
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Name</th>
+      <td mat-cell *matCellDef="let site">{{ site.name }}</td>
+    </ng-container>
+
+    <!-- Courts column -->
+    <ng-container matColumnDef="courts">
+      <th mat-header-cell *matHeaderCellDef>Courts</th>
+      <td mat-cell *matCellDef="let site">{{ site.courts?.length ?? 0 }}</td>
+    </ng-container>
+
+    <!-- Revenue column -->
+    <ng-container matColumnDef="revenue">
+      <th mat-header-cell *matHeaderCellDef>Revenue</th>
+      <td mat-cell *matCellDef="let site">{{ site.revenue ?? 0 }}€</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="['name', 'courts', 'revenue']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['name', 'courts', 'revenue'];"></tr>
+  </table>
+</div>
+
+<app-pagination
+  [totalItems]="(this.siteService.page$ | async)?.totalItems ?? 0"
+  [pageIndex]="(this.siteService.request$ | async)?.pageIndex ?? 0"
+  [pageSize]="(this.siteService.request$ | async)?.pageSize ?? 10"
+  [loading]="loading()"
+  (pageChange)="this.siteService.onPageChange($event)"
+/>

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
@@ -1,15 +1,4 @@
-<h2>list of all the paddel sites!</h2>
-
-<!--<div class="list" [class.loading]="loading()">-->
-<!--  <mat-list>-->
-<!--    @for (site of this.items$ | async; track site.id) {-->
-<!--      <mat-list-item>-->
-<!--        <span matListItemTitle>{{ site.name }}</span>-->
-<!--        <span matListItemLine>{{ site.courts.length }} courts</span>-->
-<!--      </mat-list-item>-->
-<!--    }-->
-<!--  </mat-list>-->
-<!--</div>-->
+<h2>List of all the Padel sites!</h2>
 
 <div class="list" [class.loading]="loading()">
   <table mat-table [dataSource]="(items$ | async) ?? []" class="mat-elevation-z1">
@@ -32,8 +21,8 @@
       <td mat-cell *matCellDef="let site">{{ site.revenue ?? 0 }}€</td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="['name', 'courts', 'revenue']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['name', 'courts', 'revenue'];"></tr>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
 </div>
 

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.spec.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SiteList } from './site-list';
+
+describe('SiteList', () => {
+  let component: SiteList;
+  let fixture: ComponentFixture<SiteList>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SiteList]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SiteList);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.ts
@@ -1,0 +1,27 @@
+import { Component, inject, signal } from '@angular/core';
+import { SiteService } from "../../services/site-service";
+import {PaginationComponent} from '../../../../shared/components/pagination/pagination.component';
+import {AsyncPipe} from '@angular/common';
+import {Site} from '../../types/site';
+import {map} from 'rxjs/operators';
+import {MatListModule} from '@angular/material/list';
+import {MatTableModule} from '@angular/material/table';
+
+@Component({
+  selector: 'app-site-list',
+  imports: [
+    PaginationComponent,
+    AsyncPipe,
+    MatListModule,
+    MatTableModule
+  ],
+  templateUrl: './site-list.html',
+  styleUrl: './site-list.css',
+})
+
+export class SiteList {
+  loading = signal(false);
+  readonly siteService = inject(SiteService);
+  readonly items$ = this.siteService.page$.pipe(map(page => page.items as Site[]));
+  protected readonly Site = Site;
+}

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/components/site-list/site-list.ts
@@ -1,27 +1,27 @@
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { SiteService } from "../../services/site-service";
-import {PaginationComponent} from '../../../../shared/components/pagination/pagination.component';
-import {AsyncPipe} from '@angular/common';
-import {Site} from '../../types/site';
-import {map} from 'rxjs/operators';
-import {MatListModule} from '@angular/material/list';
-import {MatTableModule} from '@angular/material/table';
+import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
+import { AsyncPipe } from '@angular/common';
+import { Site } from '../../types/site';
+import { map } from 'rxjs/operators';
+import { MatTableModule } from '@angular/material/table';
 
 @Component({
   selector: 'app-site-list',
   imports: [
     PaginationComponent,
     AsyncPipe,
-    MatListModule,
     MatTableModule
   ],
   templateUrl: './site-list.html',
   styleUrl: './site-list.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 
 export class SiteList {
   loading = signal(false);
   readonly siteService = inject(SiteService);
   readonly items$ = this.siteService.page$.pipe(map(page => page.items as Site[]));
-  protected readonly Site = Site;
+
+  readonly displayedColumns = ['name', 'courts', 'revenue']
 }

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/services/site-service.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/services/site-service.ts
@@ -71,7 +71,8 @@ export class SiteService {
       openingHours: '08:00',
       closingHours: '22:00',
       closedDays: ['Sunday'],
-      courts: ['Court A', 'Court B', 'Court C']
+      courts: ['Court A', 'Court B', 'Court C'],
+      revenue: 128450
     },
     {
       id: 2,
@@ -79,7 +80,8 @@ export class SiteService {
       openingHours: '07:30',
       closingHours: '21:30',
       closedDays: ['Monday'],
-      courts: ['Court 1', 'Court 2']
+      courts: ['Court 1', 'Court 2'],
+      revenue: 84200
     },
     {
       id: 3,
@@ -87,7 +89,8 @@ export class SiteService {
       openingHours: '09:00',
       closingHours: '20:00',
       closedDays: [],
-      courts: ['Indoor 1', 'Indoor 2', 'Outdoor 1']
+      courts: ['Indoor 1', 'Indoor 2', 'Outdoor 1'],
+      revenue: 61350
     },
     {
       id: 4,
@@ -95,7 +98,8 @@ export class SiteService {
       openingHours: '10:00',
       closingHours: '19:00',
       closedDays: ['Saturday'],
-      courts: ['Clay 1', 'Clay 2', 'Clay 3', 'Clay 4']
+      courts: ['Clay 1', 'Clay 2', 'Clay 3', 'Clay 4'],
+      revenue: 45500
     },
     {
       id: 5,
@@ -103,7 +107,8 @@ export class SiteService {
       openingHours: '06:00',
       closingHours: '23:00',
       closedDays: [],
-      courts: ['Hall A', 'Hall B']
+      courts: ['Hall A', 'Hall B'],
+      revenue: 173900
     },
     {
       id: 6,
@@ -111,7 +116,8 @@ export class SiteService {
       openingHours: '08:30',
       closingHours: '21:00',
       closedDays: ['Tuesday'],
-      courts: ['Lake 1', 'Lake 2', 'Lake 3']
+      courts: ['Lake 1', 'Lake 2', 'Lake 3'],
+      revenue: 98750
     },
     {
       id: 7,
@@ -119,7 +125,8 @@ export class SiteService {
       openingHours: '07:00',
       closingHours: '22:30',
       closedDays: [],
-      courts: ['Gym 1']
+      courts: ['Gym 1'],
+      revenue: 52100
     },
     {
       id: 8,
@@ -127,7 +134,8 @@ export class SiteService {
       openingHours: '09:30',
       closingHours: '18:30',
       closedDays: ['Sunday'],
-      courts: ['Hill 1', 'Hill 2']
+      courts: ['Hill 1', 'Hill 2'],
+      revenue: 33700
     },
     {
       id: 9,
@@ -135,7 +143,8 @@ export class SiteService {
       openingHours: '08:00',
       closingHours: '20:30',
       closedDays: ['Sunday'],
-      courts: ['Uni A', 'Uni B', 'Uni C', 'Uni D']
+      courts: ['Uni A', 'Uni B', 'Uni C', 'Uni D'],
+      revenue: 110500
     },
     {
       id: 10,
@@ -143,7 +152,8 @@ export class SiteService {
       openingHours: '11:00',
       closingHours: '17:00',
       closedDays: ['Wednesday'],
-      courts: ['Community 1', 'Community 2']
+      courts: ['Community 1', 'Community 2'],
+      revenue: 21400
     },
     {
       id: 11,
@@ -151,7 +161,8 @@ export class SiteService {
       openingHours: '08:00',
       closingHours: '19:30',
       closedDays: [],
-      courts: ['Forest 1', 'Forest 2', 'Forest 3']
+      courts: ['Forest 1', 'Forest 2', 'Forest 3'],
+      revenue: 58700
     },
     {
       id: 12,
@@ -159,7 +170,8 @@ export class SiteService {
       openingHours: '07:00',
       closingHours: '21:00',
       closedDays: ['Monday'],
-      courts: ['DT 1', 'DT 2']
+      courts: ['DT 1', 'DT 2'],
+      revenue: 76500
     },
     {
       id: 13,
@@ -167,7 +179,8 @@ export class SiteService {
       openingHours: '08:00',
       closingHours: '20:00',
       closedDays: ['Sunday'],
-      courts: ['Harbor 1']
+      courts: ['Harbor 1'],
+      revenue: 40900
     },
     {
       id: 14,
@@ -175,7 +188,8 @@ export class SiteService {
       openingHours: '09:00',
       closingHours: '18:00',
       closedDays: ['Thursday'],
-      courts: ['Meadow 1', 'Meadow 2', 'Meadow 3']
+      courts: ['Meadow 1', 'Meadow 2', 'Meadow 3'],
+      revenue: 37250
     },
     {
       id: 15,
@@ -183,7 +197,8 @@ export class SiteService {
       openingHours: '06:30',
       closingHours: '23:00',
       closedDays: [],
-      courts: ['Main 1', 'Main 2', 'Main 3', 'Main 4', 'Main 5']
+      courts: ['Main 1', 'Main 2', 'Main 3', 'Main 4', 'Main 5'],
+      revenue: 225000
     }
   ];
   /**

--- a/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/types/site.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/pages/sites-list/types/site.ts
@@ -5,6 +5,7 @@ export class Site {
   closingHours!: string;
   closedDays!: string[];
   courts!: string[];
+  revenue!: number;
 }
 
 export type SiteDto = Site;

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/layout/menu/menu.component.html
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/layout/menu/menu.component.html
@@ -5,6 +5,6 @@
 </mat-toolbar>
 
 <a routerLink="home" mat-list-item>Home</a>
-<a routerLink="catalog" mat-list-item>Catalogue</a>
+<a routerLink="sites" mat-list-item>Sites</a>
 <a routerLink="create" mat-list-item>Créer</a>
 

--- a/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.ts
+++ b/ProjetWeb.Frontend/Frontend/src/app/views/shared/components/pagination/pagination.component.ts
@@ -5,7 +5,6 @@ import { PageRequest } from '../../types/paging';
 
 @Component({
   selector: 'app-pagination',
-  standalone: true,
   imports: [CommonModule, MatPaginatorModule],
   templateUrl: './pagination.component.html',
   styleUrl: './pagination.component.css',


### PR DESCRIPTION
This pull request introduces a new "Sites" page to the frontend, allowing users to view a paginated list of all padel sites, including their names, number of courts, and revenue. It adds routing, a new component with its template and test, updates the data model and service to include revenue, and updates the main menu for navigation.

**Feature: Site List Page**

* Added a new route `/sites` pointing to the new `SiteList` component in `app.routes.ts`.
* Implemented the `SiteList` component, including logic to fetch and display site data, and integrated pagination and Angular Material table for UI.
* Created a template for `SiteList` that displays site name, number of courts, and revenue in a table, with pagination controls.
* Added a basic unit test for the `SiteList` component to verify its creation.

**Data Model and Service Updates**

* Extended the `Site` model and the mock data in `SiteService` to include the `revenue` field for each site. [[1]](diffhunk://#diff-f41a33c94fb31cf24a1e2773a0c06edb5183ea7f98998430df07385a229ba547R8) [[2]](diffhunk://#diff-f377fd7fec2be0a63b02cef8687bcf5ffaad8c07145ddbf8485e0fdd157e3465L74-R201)

**Navigation**

* Updated the main menu to include a link to the new "Sites" page, replacing the previous "Catalogue" link.