### PR TITLE
Fix frontend build context path in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Frontend service - Angular 21 application
   frontend:
     build:
-      context: ./ProjetWeb.Frontend/Frontend
+      context: ./ProjetWeb.Frontend
       dockerfile: Dockerfile
     ports:
       - "4200:80"


### PR DESCRIPTION
This pull request makes a minor update to the frontend service configuration in `docker-compose.yml`, adjusting the build context path for the frontend application. This change ensures Docker uses the correct directory when building the frontend image.