### PR TITLE
Add refresh token revocation and logout endpoint

### DIFF
--- a/AuthService/BL/Services/Abstractions/IAuthService.cs
+++ b/AuthService/BL/Services/Abstractions/IAuthService.cs
@@ -7,4 +7,5 @@ public interface IAuthService
     Task<AuthResponse> LoginAsync(LoginRequest request);
     Task<AuthResponse?> RefreshTokenAsync(string refreshToken);
     Task<AuthResponse> RegisterAsync(RegisterRequest request);
+    Task RevokeTokenAsnc(string refreshToken);
 }

--- a/AuthService/BL/Services/Abstractions/IAuthService.cs
+++ b/AuthService/BL/Services/Abstractions/IAuthService.cs
@@ -7,5 +7,5 @@ public interface IAuthService
     Task<AuthResponse> LoginAsync(LoginRequest request);
     Task<AuthResponse?> RefreshTokenAsync(string refreshToken);
     Task<AuthResponse> RegisterAsync(RegisterRequest request);
-    Task RevokeTokenAsnc(string refreshToken);
+    Task RevokeTokenAsync(string refreshToken);
 }

--- a/AuthService/BL/Services/AuthenticationService.cs
+++ b/AuthService/BL/Services/AuthenticationService.cs
@@ -84,17 +84,18 @@ public class AuthenticationService : IAuthService
         return await GenerateAuthResponseAsync(user);
     }
 
-    public async Task RevokeTokenAsnc(string refreshToken)
+    public async Task RevokeTokenAsync(string refreshToken)
     {
         var storedToken = await _dbContext.RefreshTokens.FirstOrDefaultAsync(rt => rt.Token == refreshToken);
+        var maskedToken = string.Concat(refreshToken.AsSpan(0, Math.Min(8, refreshToken.Length)), "...");
         if (storedToken == null || storedToken.IsRevoked)
         {
-            _logger.LogWarning("Attempt to revoke invalid or already revoked token: {Token}", refreshToken);
+            _logger.LogWarning("Attempt to revoke invalid or already revoked token: {Token}", maskedToken);
             throw new InvalidOperationException("The provided refresh token is invalid or already revoked.");
         }
         storedToken.IsRevoked = true;
         await _dbContext.SaveChangesAsync();
-        _logger.LogInformation("Refresh token revoked: {Token}", refreshToken);
+        _logger.LogInformation("Refresh token revoked: {Token}", maskedToken);
     }
 
     private async Task<AuthResponse> GenerateAuthResponseAsync(User user)

--- a/AuthService/Controllers/AuthController.cs
+++ b/AuthService/Controllers/AuthController.cs
@@ -47,7 +47,7 @@ public class AuthController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> Logout([FromBody] RefreshTokenRequest refreshTokenRequest)
     {
-        await _authService.RevokeTokenAsnc(refreshTokenRequest.RefreshToken);
+        await _authService.RevokeTokenAsync(refreshTokenRequest.RefreshToken);
         return NoContent();
     }
 }

--- a/AuthService/Controllers/AuthController.cs
+++ b/AuthService/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 ﻿using AuthService.BL.Models;
 using AuthService.BL.Services.Abstractions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace AuthService.Controllers;
@@ -39,5 +40,14 @@ public class AuthController : ControllerBase
             ?? throw new UnauthorizedAccessException("The provided refresh token is invalid or has expired.");
 
         return Ok(response);
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> Logout([FromBody] RefreshTokenRequest refreshTokenRequest)
+    {
+        await _authService.RevokeTokenAsnc(refreshTokenRequest.RefreshToken);
+        return NoContent();
     }
 }


### PR DESCRIPTION
This pull request adds support for securely revoking refresh tokens, enabling a logout endpoint in the authentication service. The main changes include introducing a new method to revoke tokens, updating the service interface, and exposing a protected logout API endpoint.

**Refresh token revocation support:**

* Added a new `RevokeTokenAsnc` method to the `IAuthService` interface to allow explicit revocation of refresh tokens.
* Implemented the `RevokeTokenAsnc` method in `AuthenticationService` to mark tokens as revoked in the database and log the operation.

**API endpoint changes:**

* Added a new `[Authorize]`-protected `POST /logout` endpoint in `AuthController` that calls the new revoke method and returns HTTP 204 on success.
* Added the necessary `using Microsoft.AspNetCore.Authorization;` directive to support endpoint protection.