### PR TITLE
Add JWT auth and rate limiting via service helper

### DIFF
--- a/AuthService/Infrastructure/Options/RateLimitOptions.cs
+++ b/AuthService/Infrastructure/Options/RateLimitOptions.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AuthService.Infrastructure.Options;
+
+public class RateLimitOptions
+{
+    public const string SectionName = "RateLimiting";
+
+    public GlobalRateLimitOptions Global { get; init; } = new();
+    public AuthRateLimitOptions Auth { get; init; } = new();
+
+    [Range(1, 300)]
+    public int RetryAfterSeconds { get; init; } = 60;
+}
+
+public class GlobalRateLimitOptions
+{
+    [Range(1, 10000)]
+    public int TokenLimit { get; init; } = 100;
+
+    [Range(1, 60)]
+    public int ReplenishmentPeriodMinutes { get; init; } = 1;
+
+    [Range(1, 10000)]
+    public int TokensPerPeriod { get; init; } = 100;
+
+    [Range(0, 100)]
+    public int QueueLimit { get; init; } = 0;
+}
+
+public class AuthRateLimitOptions
+{
+    [Range(1, 1000)]
+    public int TokenLimit { get; init; } = 10;
+
+    [Range(1, 60)]
+    public int ReplenishmentPeriodMinutes { get; init; } = 1;
+
+    [Range(1, 1000)]
+    public int TokensPerPeriod { get; init; } = 10;
+
+    [Range(0, 100)]
+    public int QueueLimit { get; init; } = 0;
+}

--- a/AuthService/Infrastructure/ServicesRegistrationHelper.cs
+++ b/AuthService/Infrastructure/ServicesRegistrationHelper.cs
@@ -1,6 +1,7 @@
 ﻿using AuthService.Infrastructure.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -12,50 +13,57 @@ public static class ServicesRegistrationHelper
 {
     public static IServiceCollection AddRateLimiterPolicies(this IServiceCollection services)
     {
-        return services.AddRateLimiter(options =>
+        services.AddRateLimiter(options =>
         {
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-
-            // Global policy for general endpoints
-            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
-                RateLimitPartition.GetTokenBucketLimiter(
-                    partitionKey: GetClientIpAddress(context),
-                    factory: _ => new TokenBucketRateLimiterOptions
-                    {
-                        TokenLimit = 100,
-                        ReplenishmentPeriod = TimeSpan.FromMinutes(1),
-                        TokensPerPeriod = 100,
-                        AutoReplenishment = true,
-                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                        QueueLimit = 0
-                    }));
-
-            // Strict policy for authentication endpoints (login, register)
-            options.AddPolicy("auth", context =>
-                RateLimitPartition.GetTokenBucketLimiter(
-                    partitionKey: GetClientIpAddress(context),
-                    factory: _ => new TokenBucketRateLimiterOptions
-                    {
-                        TokenLimit = 10,
-                        ReplenishmentPeriod = TimeSpan.FromMinutes(1),
-                        TokensPerPeriod = 10,
-                        AutoReplenishment = true,
-                        QueueLimit = 0
-                    }));
-
-
-            options.OnRejected = async (context, cancellationToken) =>
-            {
-                context.HttpContext.Response.Headers.RetryAfter = "60";
-
-                await context.HttpContext.Response.WriteAsJsonAsync(new ProblemDetails
-                {
-                    Status = StatusCodes.Status429TooManyRequests,
-                    Title = "Too Many Requests",
-                    Detail = "Rate limit exceeded. Please try again later."
-                }, cancellationToken);
-            };
         });
+
+        services.AddOptions<RateLimiterOptions>()
+            .Configure<IOptions<RateLimitOptions>>((rateLimiterOptions, rateLimitOptions) =>
+            {
+                var config = rateLimitOptions.Value;
+
+                // Global policy for general endpoints
+                rateLimiterOptions.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+                    RateLimitPartition.GetTokenBucketLimiter(
+                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                        factory: _ => new TokenBucketRateLimiterOptions
+                        {
+                            TokenLimit = config.Global.TokenLimit,
+                            ReplenishmentPeriod = TimeSpan.FromMinutes(config.Global.ReplenishmentPeriodMinutes),
+                            TokensPerPeriod = config.Global.TokensPerPeriod,
+                            AutoReplenishment = true,
+                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                            QueueLimit = config.Global.QueueLimit
+                        }));
+
+                // Strict policy for authentication endpoints (login, register)
+                rateLimiterOptions.AddPolicy("auth", context =>
+                    RateLimitPartition.GetTokenBucketLimiter(
+                        partitionKey: context.Connection.RemoteIpAddress,
+                        factory: _ => new TokenBucketRateLimiterOptions
+                        {
+                            TokenLimit = config.Auth.TokenLimit,
+                            ReplenishmentPeriod = TimeSpan.FromMinutes(config.Auth.ReplenishmentPeriodMinutes),
+                            TokensPerPeriod = config.Auth.TokensPerPeriod,
+                            AutoReplenishment = true,
+                            QueueLimit = config.Auth.QueueLimit
+                        }));
+
+                rateLimiterOptions.OnRejected = async (context, cancellationToken) =>
+                {
+                    context.HttpContext.Response.Headers.RetryAfter = config.RetryAfterSeconds.ToString();
+
+                    await context.HttpContext.Response.WriteAsJsonAsync(new ProblemDetails
+                    {
+                        Status = StatusCodes.Status429TooManyRequests,
+                        Title = "Too Many Requests",
+                        Detail = "Rate limit exceeded. Please try again later."
+                    }, cancellationToken);
+                };
+            });
+
+        return services;
     }
 
     public static IServiceCollection AddJWTAuthentication(this IServiceCollection services)
@@ -83,18 +91,18 @@ public static class ServicesRegistrationHelper
     }
 
 
-    // Helper to extract real client IP
-    private static string GetClientIpAddress(HttpContext context)
+    public static IServiceCollection RegisterOptions(this IServiceCollection services)
     {
-        // X-Forwarded-For is parsed by UseForwardedHeaders() into Connection.RemoteIpAddress
-        // But we can also check the header directly as fallback
-        var forwardedFor = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrEmpty(forwardedFor))
-        {
-            // Take the first IP (original client)
-            return forwardedFor.Split(',')[0].Trim();
-        }
+        services.AddOptions<JwtOptions>()
+            .BindConfiguration(JwtOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
-        return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        services.AddOptions<RateLimitOptions>()
+            .BindConfiguration(RateLimitOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return services;
     }
 }

--- a/AuthService/Infrastructure/ServicesRegistrationHelper.cs
+++ b/AuthService/Infrastructure/ServicesRegistrationHelper.cs
@@ -1,0 +1,100 @@
+﻿using AuthService.Infrastructure.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using System.Threading.RateLimiting;
+
+namespace AuthService.Infrastructure;
+
+public static class ServicesRegistrationHelper
+{
+    public static IServiceCollection AddRateLimiterPolicies(this IServiceCollection services)
+    {
+        return services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            // Global policy for general endpoints
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+                RateLimitPartition.GetTokenBucketLimiter(
+                    partitionKey: GetClientIpAddress(context),
+                    factory: _ => new TokenBucketRateLimiterOptions
+                    {
+                        TokenLimit = 100,
+                        ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                        TokensPerPeriod = 100,
+                        AutoReplenishment = true,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    }));
+
+            // Strict policy for authentication endpoints (login, register)
+            options.AddPolicy("auth", context =>
+                RateLimitPartition.GetTokenBucketLimiter(
+                    partitionKey: GetClientIpAddress(context),
+                    factory: _ => new TokenBucketRateLimiterOptions
+                    {
+                        TokenLimit = 10,
+                        ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                        TokensPerPeriod = 10,
+                        AutoReplenishment = true,
+                        QueueLimit = 0
+                    }));
+
+
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                context.HttpContext.Response.Headers.RetryAfter = "60";
+
+                await context.HttpContext.Response.WriteAsJsonAsync(new ProblemDetails
+                {
+                    Status = StatusCodes.Status429TooManyRequests,
+                    Title = "Too Many Requests",
+                    Detail = "Rate limit exceeded. Please try again later."
+                }, cancellationToken);
+            };
+        });
+    }
+
+    public static IServiceCollection AddJWTAuthentication(this IServiceCollection services)
+    {
+        // JWT Authentication
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer();
+
+        services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+            .Configure<IOptions<JwtOptions>>((jwtBearerOptions, jwtOptions) =>
+            {
+                var jwt = jwtOptions.Value;
+                jwtBearerOptions.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwt.Issuer,
+                    ValidAudience = jwt.Audience,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Key))
+                };
+            });
+        return services;
+    }
+
+
+    // Helper to extract real client IP
+    private static string GetClientIpAddress(HttpContext context)
+    {
+        // X-Forwarded-For is parsed by UseForwardedHeaders() into Connection.RemoteIpAddress
+        // But we can also check the header directly as fallback
+        var forwardedFor = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(forwardedFor))
+        {
+            // Take the first IP (original client)
+            return forwardedFor.Split(',')[0].Trim();
+        }
+
+        return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+}

--- a/AuthService/Program.cs
+++ b/AuthService/Program.cs
@@ -3,11 +3,9 @@ using AuthService.BL.Services.Abstractions;
 using AuthService.DAL;
 using AuthService.Infrastructure;
 using AuthService.Infrastructure.Options;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
+using static AuthService.Infrastructure.ServicesRegistrationHelper;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,26 +28,16 @@ builder.Services.AddScoped<IAuthService, AuthenticationService>();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 
+// Rate Limiting Configuration
+builder.Services.AddRateLimiterPolicies();
+
+
 builder.Services.AddControllers(options => 
     options.Filters.Add(new ProducesDefaultResponseTypeAttribute(typeof(ProblemDetails))));
 
 
 // JWT Authentication
-var jwtOptions = builder.Configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>()!;
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddJwtBearer(options =>
-    {
-        options.TokenValidationParameters = new TokenValidationParameters
-        {
-            ValidateIssuer = true,
-            ValidateAudience = true,
-            ValidateLifetime = true,
-            ValidateIssuerSigningKey = true,
-            ValidIssuer = jwtOptions.Issuer,
-            ValidAudience = jwtOptions.Audience,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Key))
-        };
-    });
+builder.Services.AddJWTAuthentication();
 
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
@@ -64,9 +52,13 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
+app.UseForwardedHeaders();
+
 app.UseExceptionHandler();
 
 app.UseHttpsRedirection();
+
+app.UseRateLimiter();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/AuthService/appsettings.Development.json
+++ b/AuthService/appsettings.Development.json
@@ -9,5 +9,20 @@
     "Key": "your-super-secret-key-at-least-32-characters-long!",
     "Issuer": "https://localhost:5000",
     "Audience": "https://localhost:5000"
+  },
+  "RateLimiting": {
+    "RetryAfterSeconds": 60,
+    "Global": {
+      "TokenLimit": 100,
+      "ReplenishmentPeriodMinutes": 1,
+      "TokensPerPeriod": 100,
+      "QueueLimit": 0
+    },
+    "Auth": {
+      "TokenLimit": 10,
+      "ReplenishmentPeriodMinutes": 1,
+      "TokensPerPeriod": 10,
+      "QueueLimit": 0
+    }
   }
 }


### PR DESCRIPTION
Refactor JWT setup into ServicesRegistrationHelper for centralized configuration. Introduce per-IP rate limiting (global and strict "auth" policy) with 429 responses. Update middleware to support forwarded headers and rate limiting. Improve code organization with static service registration imports.