### PR TITLE
Refactor user roles to dedicated Role entity and enum

### DIFF
--- a/AuthService/BL/Models/RoleDto.cs
+++ b/AuthService/BL/Models/RoleDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Authentication.API.BL.Models;
+
+public class RoleDto
+{
+    public string RoleType { get; set; } = string.Empty;
+    public Guid? SiteId { get; set; }
+}

--- a/AuthService/BL/Models/UserDto.cs
+++ b/AuthService/BL/Models/UserDto.cs
@@ -6,5 +6,5 @@ public class UserDto
     public string Email { get; set; } = string.Empty;
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
-    public string Role { get; set; } = string.Empty;
+    public RoleDto Role { get; set; } = null!;
 }

--- a/AuthService/BL/Services/AuthService.cs
+++ b/AuthService/BL/Services/AuthService.cs
@@ -82,7 +82,7 @@ public class AuthService : IAuthService
         }
 
         var user = await _dbContext.Users
-             .Include(u => u.Role)
+            .Include(u => u.Role)
             .FirstOrDefaultAsync(u => u.Id == storedToken.UserId);
 
         if (user == null || !user.IsActive)

--- a/AuthService/BL/Services/AuthService.cs
+++ b/AuthService/BL/Services/AuthService.cs
@@ -37,7 +37,11 @@ public class AuthService : IAuthService
             Email = request.Email,
             FirstName = request.FirstName,
             LastName = request.LastName,
-            Role = "User",
+            Role = new Role
+            {
+                Id = Guid.NewGuid(),
+                RoleType = RoleType.User
+            },
             PasswordHash = HashPassword(request.Password)
         };
         _dbContext.Users.Add(user);
@@ -49,7 +53,9 @@ public class AuthService : IAuthService
 
     public async Task<AuthResponse> LoginAsync(LoginRequest request)
     {
-        var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Email == request.Email);
+        var user = await _dbContext.Users
+            .Include(u => u.Role).FirstOrDefaultAsync(u => u.Email == request.Email);
+
         if (user == null || !Verify(request.Password, user.PasswordHash))
         {
             _logger.LogWarning("Failed login attempt for email: {Email}", request.Email);
@@ -71,11 +77,14 @@ public class AuthService : IAuthService
         if (storedToken == null || storedToken.IsRevoked || storedToken.ExpiresAt <= DateTime.UtcNow)
         {
             _logger.LogWarning("Invalid, revoked, or expired refresh token received for refresh: {Token}", maskedToken);
-            
+
             throw new InvalidOperationException("The provided refresh token is invalid, revoked, or expired.");
         }
 
-        var user = await _dbContext.Users.FindAsync(storedToken.UserId);
+        var user = await _dbContext.Users
+             .Include(u => u.Role)
+            .FirstOrDefaultAsync(u => u.Id == storedToken.UserId);
+
         if (user == null || !user.IsActive)
         {
             _logger.LogWarning($"Refresh token refresh failed for non-existent or inactive user. Token: {maskedToken}, UserId: {storedToken.UserId}");
@@ -131,7 +140,11 @@ public class AuthService : IAuthService
                 Email = user.Email,
                 FirstName = user.FirstName,
                 LastName = user.LastName,
-                Role = user.Role
+                Role = new RoleDto
+                {                    
+                    RoleType = user.Role.RoleType.ToString(),
+                    SiteId = user.Role.SiteId
+                }
             }
         };
     }

--- a/AuthService/BL/Services/TokenService.cs
+++ b/AuthService/BL/Services/TokenService.cs
@@ -32,7 +32,7 @@ public class TokenService : ITokenService
             new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
             new Claim(JwtRegisteredClaimNames.Email, user.Email),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new Claim(ClaimTypes.Role, user.Role),
+            new Claim(ClaimTypes.Role, user.Role.RoleType.ToString()),
             new Claim(ClaimTypes.GivenName, user.FirstName ?? string.Empty),
             new Claim(ClaimTypes.Surname, user.LastName ?? string.Empty)
 

--- a/AuthService/DAL/Configurations/RoleConfiguration.cs
+++ b/AuthService/DAL/Configurations/RoleConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using Authentication.API.DAL.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using System.Reflection.Emit;
 
 namespace Authentication.API.DAL.Configurations;
 
@@ -19,8 +18,5 @@ public class RoleConfiguration : IEntityTypeConfiguration<Role>
             .WithOne(u => u.Role)
             .HasForeignKey<Role>(r => r.UserId)
             .OnDelete(DeleteBehavior.Cascade);
-
-        builder.HasIndex(r => new { r.UserId, r.SiteId })
-              .IsUnique();
     }
 }

--- a/AuthService/DAL/Configurations/RoleConfiguration.cs
+++ b/AuthService/DAL/Configurations/RoleConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Authentication.API.DAL.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System.Reflection.Emit;
+
+namespace Authentication.API.DAL.Configurations;
+
+public class RoleConfiguration : IEntityTypeConfiguration<Role>
+{
+    public void Configure(EntityTypeBuilder<Role> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.RoleType)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.HasOne(r => r.User)
+            .WithOne(u => u.Role)
+            .HasForeignKey<Role>(r => r.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(r => new { r.UserId, r.SiteId })
+              .IsUnique();
+    }
+}

--- a/AuthService/DAL/Entities/Role.cs
+++ b/AuthService/DAL/Entities/Role.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Authentication.API.DAL.Entities;
+
+public class Role
+{
+    public Guid Id { get; set; }
+
+    [Required]
+    public RoleType RoleType { get; set; } = RoleType.User;
+
+    /// <summary>
+    /// For site-specific roles (UserPremium, Admin). Null for global roles.
+    /// </summary>
+    public Guid? SiteId { get; set; }
+
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+}

--- a/AuthService/DAL/Entities/RoleType.cs
+++ b/AuthService/DAL/Entities/RoleType.cs
@@ -1,0 +1,10 @@
+namespace Authentication.API.DAL.Entities;
+
+public enum RoleType
+{
+    User = 0,
+    UserPremium = 1,
+    UserPremiumPlus = 2,
+    Admin = 3,
+    GlobalAdmin = 4
+}

--- a/AuthService/DAL/Entities/User.cs
+++ b/AuthService/DAL/Entities/User.cs
@@ -21,5 +21,5 @@ public class User
 
     public bool IsActive { get; set; } = true;
 
-    public string Role { get; set; } = "User";
+    public Role Role { get; set; } = null!;
 }


### PR DESCRIPTION
Replaced string-based user roles with a Role entity and RoleType enum. Updated User, UserDto, and AuthService to use Role navigation property and RoleDto. Added RoleType enum and RoleConfiguration for EF Core. JWT claims now use RoleType. All queries and mappings updated for new role model.