### PR TITLE
Improve API client generation docs and update build scripts

### DIFF
--- a/ProjetWeb.Frontend/README.md
+++ b/ProjetWeb.Frontend/README.md
@@ -2,6 +2,12 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 21.0.3.
 
+## Documentation
+
+📚 **[API Client Generation Docs](./docs/README.md)**
+
+- 📘 [Complete Guide](./docs/typescript-client-generation.md) - Full reference
+
 ## Development server
 
 To start a local development server, run:
@@ -11,6 +17,16 @@ ng serve
 ```
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
+
+## API Client Generation
+
+To generate TypeScript API clients from OpenAPI specifications:
+
+```bash
+npm run gen:auth
+```
+
+This generates type-safe Angular services from the backend API. See the [documentation](./docs/typescript-client-generation.md) for details.
 
 ## Code scaffolding
 
@@ -36,21 +52,6 @@ ng build
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
 
-## Running unit tests
-
-To execute unit tests with the [Vitest](https://vitest.dev/) test runner, use the following command:
-
-```bash
-ng test
-```
-
-## Running end-to-end tests
-
-For end-to-end (e2e) testing, run:
-
-```bash
-ng e2e
-```
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 

--- a/ProjetWeb.Frontend/docs/typescript-client-generation.md
+++ b/ProjetWeb.Frontend/docs/typescript-client-generation.md
@@ -1,0 +1,171 @@
+# TypeScript Client Generation
+
+## Overview
+
+This project uses [OpenAPI Generator](https://openapi-generator.tech/) to automatically generate type-safe TypeScript API clients from .NET backend OpenAPI specifications.
+
+**Flow:** `.NET Backend` → `OpenAPI JSON` → `Generator` → `Angular TypeScript Client`
+
+## Quick Start
+
+```bash
+# Generate auth client
+npm run gen:auth
+
+# Location
+src/app/core/api/auth/
+
+# Import
+import { AuthService, LoginRequest } from '@/core/api/auth';
+```
+
+## Configuration
+
+### Generator Version
+
+Set in `openapitools.json`:
+```json
+{
+  "generator-cli": {
+    "version": "7.19.0"
+  }
+}
+```
+
+### Generation Script
+
+In `package.json`:
+```json
+{
+  "scripts": {
+    "gen:auth": "openapi-generator-cli generate -i ../AuthService/Authentication.API.json -g typescript-angular -o src/app/core/api/auth --additional-properties=fileNaming=kebab-case,serviceSuffix=Service,useHttpClient=true,standalone=true"
+  }
+}
+```
+
+**Parameters:**
+- `-i`: Input OpenAPI spec file
+- `-g`: Generator (typescript-angular)
+- `-o`: Output directory
+- `fileNaming=kebab-case`: File naming style
+- `serviceSuffix=Service`: Add "Service" suffix
+- `useHttpClient=true`: Use Angular HttpClient
+- `standalone=true`: Angular 21 standalone mode
+
+## Generated Structure
+
+```
+src/app/core/api/auth/
+├── api/
+│   └── auth.service.ts      # HTTP service methods
+├── model/
+│   ├── login-request.ts     # Request/response types
+│   ├── auth-response.ts
+│   └── ...
+├── configuration.ts         # API config (base URL, etc.)
+└── index.ts                # Barrel exports
+```
+
+## Usage
+
+### Basic Example
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { AuthService, LoginRequest } from '@/core/api/auth';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  template: `...`
+})
+export class LoginComponent {
+  private authService = inject(AuthService);
+
+  login(email: string, password: string): void {
+    this.authService.apiAuthLoginPost({ email, password }).subscribe({
+      next: (response) => console.log('Token:', response.token),
+      error: (error) => console.error('Login failed:', error)
+    });
+  }
+}
+```
+
+### Configure Base URL
+
+```typescript
+// app.config.ts
+import { Configuration } from '@/core/api/auth';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(),
+    provideApi('https://localhost:7001')
+  ]
+};
+```
+
+### Add Auth Interceptor
+
+```typescript
+// auth.interceptor.ts
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = localStorage.getItem('auth_token');
+  if (token) {
+    req = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` }
+    });
+  }
+  return next(req);
+};
+
+// app.config.ts
+provideHttpClient(withInterceptors([authInterceptor]))
+```
+
+## Workflow
+
+### When to Regenerate
+- Backend API endpoints change
+- Request/response models change
+- After pulling backend updates
+
+### Process
+1. Update backend API
+2. Ensure OpenAPI spec is exported: `AuthService/Authentication.API.json`
+3. Run: `npm run gen:auth`
+4. Review: `git diff src/app/core/api/auth/`
+5. Update frontend if breaking changes
+6. Test
+
+### Preserve Custom Files
+
+Add to `.openapi-generator-ignore`:
+```
+configuration.ts
+api.base.service.ts
+```
+
+## Adding New Services
+
+```json
+// package.json
+{
+  "scripts": {
+    "gen:auth": "openapi-generator-cli generate -i ../AuthService/Authentication.API.json -g typescript-angular -o src/app/core/api/auth --additional-properties=fileNaming=kebab-case,serviceSuffix=Service,useHttpClient=true,standalone=true",
+    "gen:orders": "openapi-generator-cli generate -i ../OrderService/Orders.API.json -g typescript-angular -o src/app/core/api/orders --additional-properties=fileNaming=kebab-case,serviceSuffix=Service,useHttpClient=true,standalone=true"
+  }
+}
+```
+
+## Best Practices
+
+✅ Commit all generated files to track API changes  
+✅ Never manually edit generated files  
+✅ Use `.openapi-generator-ignore` for customizations  
+✅ Test after regeneration 
+
+---
+
+**Generator:** OpenAPI Generator 7.19.0  
+**Angular:** 21.0.0  

--- a/ProjetWeb.Frontend/package.json
+++ b/ProjetWeb.Frontend/package.json
@@ -3,9 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "prestart": "npm run gen:auth",
     "start": "ng serve",
-    "build": "npm run gen:auth && ng build",
+    "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "gen:auth": "openapi-generator-cli generate -i ../AuthService/Authentication.API.json -g typescript-angular -o src/app/core/api/auth --additional-properties=fileNaming=kebab-case,serviceSuffix=Service,useHttpClient=true,standalone=true"


### PR DESCRIPTION
- Add detailed docs/typescript-client-generation.md with usage, config, and workflow for OpenAPI TypeScript client generation
- Update README: add API client generation section, link to new docs, clarify build instructions, and remove test sections
- Remove automatic client generation from build/prestart scripts; make it a manual step via npm run gen:auth
- Enhance documentation clarity for frontend API integration