### PR TITLE
Add Revenue property to Site and update API responses

### DIFF
--- a/ProjetWeb.Shared.Migration/MigrationOptions.cs
+++ b/ProjetWeb.Shared.Migration/MigrationOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ProjetWeb.Shared.Migration;
+
+public class MigrationOptions
+{
+    public const string Key = "Migration";
+    public bool StopAfterExecution { get; set; } = true;
+}

--- a/ProjetWeb.Shared.Migration/MigrationOptions.cs
+++ b/ProjetWeb.Shared.Migration/MigrationOptions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ProjetWeb.Shared.Migration;
-
+﻿namespace ProjetWeb.Shared.Migration;
 public class MigrationOptions
 {
     public const string Key = "Migration";

--- a/ProjetWeb.Shared.Migration/SqlServerMigrationWorker.cs
+++ b/ProjetWeb.Shared.Migration/SqlServerMigrationWorker.cs
@@ -40,7 +40,7 @@ where TDbContext : DbContext
             var canConnect = await dbContext.Database.CanConnectAsync(token);
             if (!canConnect)
             {
-                throw new InvalidOperationException("Unable to connect to the authentication database.");
+                throw new InvalidOperationException($"Unable to connect to the {typeof(TDbContext).Name} database.");
             }
 
             var pendingMigrations = await dbContext.Database.GetPendingMigrationsAsync(token);

--- a/SiteManagement.API/BL/Mappers/SiteMapper.cs
+++ b/SiteManagement.API/BL/Mappers/SiteMapper.cs
@@ -5,7 +5,7 @@ namespace SiteManagement.API.BL.Mappers;
 
 public static class SiteMapper
 {
-    public static SiteResponse ToResponse(Site site)
+    public static SiteDetailsResponse ToResponseDetails(Site site)
     {
         var courtResponses = site.Courts
             .OrderBy(c => c.Number)
@@ -31,12 +31,24 @@ public static class SiteMapper
             ))
             .ToList();
 
-        return new SiteResponse(
+        return new SiteDetailsResponse(
             site.Id,
             site.Name,
+            site.Revenue,
             site.ClosedDays.OrderBy(d => d).ToList(),
             courtResponses,
             schedule
+        );
+    }
+
+    public static SiteResponse ToResponse(Site site)
+    {
+        return new SiteResponse(
+            site.Id,
+            site.Name,
+            site.Revenue,
+            site.ClosedDays.OrderBy(d => d).ToList(),
+            site.Courts.Count
         );
     }
 }

--- a/SiteManagement.API/BL/Models/SiteDetailsResponse.cs
+++ b/SiteManagement.API/BL/Models/SiteDetailsResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace SiteManagement.API.BL.Models;
+
+
+public record SiteDetailsResponse(
+    Guid Id,
+    string Name,
+    decimal Revenue,
+    IReadOnlyCollection<DateOnly> ClosedDays,
+    IReadOnlyCollection<CourtResponse> Courts,
+    IReadOnlyCollection<PlannedDayResponse> Schedule
+);
+

--- a/SiteManagement.API/BL/Models/SiteResponse.cs
+++ b/SiteManagement.API/BL/Models/SiteResponse.cs
@@ -3,7 +3,7 @@ namespace SiteManagement.API.BL.Models;
 public record SiteResponse(
     Guid Id,
     string Name,
+    decimal Revenue,
     IReadOnlyCollection<DateOnly> ClosedDays,
-    IReadOnlyCollection<CourtResponse> Courts,
-    IReadOnlyCollection<PlannedDayResponse> Schedule
+    int CourtsCount
 );

--- a/SiteManagement.API/BL/Services/Abstractions/ISiteService.cs
+++ b/SiteManagement.API/BL/Services/Abstractions/ISiteService.cs
@@ -5,10 +5,10 @@ namespace SiteManagement.API.BL.Services.Abstractions;
 
 public interface ISiteService
 {
-    Task<SiteResponse?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<SiteDetailsResponse?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<SiteResponse>> GetAllAsync(CancellationToken cancellationToken = default);
-    Task<SiteResponse> CreateAsync(CreateSiteRequest request, CancellationToken cancellationToken = default);
-    Task<SiteResponse?> UpdateAsync(Guid id, UpdateSiteRequest request, CancellationToken cancellationToken = default);
+    Task<SiteDetailsResponse> CreateAsync(CreateSiteRequest request, CancellationToken cancellationToken = default);
+    Task<SiteDetailsResponse?> UpdateAsync(Guid id, UpdateSiteRequest request, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     Task<TimeSlotResponse?> BookTimeSlotAsync(Guid siteId, BookTimeSlotRequest request, CancellationToken cancellationToken = default);
     Task<PageOf<SiteResponse>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default);

--- a/SiteManagement.API/Controllers/SitesController.cs
+++ b/SiteManagement.API/Controllers/SitesController.cs
@@ -6,6 +6,7 @@ using ToolBox.EntityFramework.Filters;
 
 namespace SiteManagement.API.Controllers;
 
+[AllowAnonymous]
 [ApiController]
 [Route("api/[controller]")]
 public class SitesController(ISiteService siteService) : ControllerBase
@@ -20,7 +21,7 @@ public class SitesController(ISiteService siteService) : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    [ProducesResponseType<SiteResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<SiteDetailsResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
@@ -46,7 +47,7 @@ public class SitesController(ISiteService siteService) : ControllerBase
     }
 
     [HttpPost]
-    [ProducesResponseType<SiteResponse>(StatusCodes.Status201Created)]
+    [ProducesResponseType<SiteDetailsResponse>(StatusCodes.Status201Created)]
     [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> Create([FromBody] CreateSiteRequest request, CancellationToken cancellationToken)
@@ -56,7 +57,7 @@ public class SitesController(ISiteService siteService) : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    [ProducesResponseType<SiteResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<SiteDetailsResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]

--- a/SiteManagement.API/Controllers/SitesController.cs
+++ b/SiteManagement.API/Controllers/SitesController.cs
@@ -6,7 +6,6 @@ using ToolBox.EntityFramework.Filters;
 
 namespace SiteManagement.API.Controllers;
 
-[AllowAnonymous]
 [ApiController]
 [Route("api/[controller]")]
 public class SitesController(ISiteService siteService) : ControllerBase

--- a/SiteManagement.API/DAL/Configurations/SiteConfiguration.cs
+++ b/SiteManagement.API/DAL/Configurations/SiteConfiguration.cs
@@ -14,6 +14,10 @@ public class SiteConfiguration : IEntityTypeConfiguration<Site>
             .IsRequired()
             .HasMaxLength(200);
 
+        builder.Property(s => s.Revenue)
+            .IsRequired()
+            .HasColumnType("decimal(18,2)");
+
         builder.Property(s => s.ClosedDays)
             .HasConversion(
                 v => string.Join(',', v.Select(d => d.ToString("O"))),

--- a/SiteManagement.API/DAL/Entities/Site.cs
+++ b/SiteManagement.API/DAL/Entities/Site.cs
@@ -4,6 +4,7 @@ public class Site
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
+    public decimal Revenue { get; set; }
     public HashSet<DateOnly> ClosedDays { get; set; } = [];
 
     // Navigation properties

--- a/SiteManagement.API/DAL/SiteManagementDbContext.cs
+++ b/SiteManagement.API/DAL/SiteManagementDbContext.cs
@@ -3,6 +3,7 @@ using SiteManagement.API.DAL.Entities;
 
 namespace SiteManagement.API.DAL;
 
+// dotnet ef migrations add AddRevenueProperty --project SiteManagement.API/SiteManagement.API.csproj --startup-project SiteManagement.API/SiteManagement.API.csproj
 public class SiteManagementDbContext(DbContextOptions<SiteManagementDbContext> options) : DbContext(options)
 {
     public DbSet<Site> Sites { get; set; }

--- a/SiteManagement.API/Migrations/20260207220208_AddRevenueProperty.Designer.cs
+++ b/SiteManagement.API/Migrations/20260207220208_AddRevenueProperty.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SiteManagement.API.DAL;
 
@@ -11,9 +12,11 @@ using SiteManagement.API.DAL;
 namespace SiteManagement.API.Migrations
 {
     [DbContext(typeof(SiteManagementDbContext))]
-    partial class SiteManagementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260207220208_AddRevenueProperty")]
+    partial class AddRevenueProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SiteManagement.API/Migrations/20260207220208_AddRevenueProperty.cs
+++ b/SiteManagement.API/Migrations/20260207220208_AddRevenueProperty.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SiteManagement.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRevenueProperty : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Revenue",
+                table: "Sites",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Revenue",
+                table: "Sites");
+        }
+    }
+}

--- a/SiteManagement.API/SiteManagement.API.json
+++ b/SiteManagement.API/SiteManagement.API.json
@@ -172,17 +172,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               }
             }
@@ -292,17 +292,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               }
             }
@@ -430,17 +430,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SiteResponse"
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
                 }
               }
             }
@@ -1219,10 +1219,11 @@
           }
         }
       },
-      "SiteResponse": {
+      "SiteDetailsResponse": {
         "required": [
           "id",
           "name",
+          "revenue",
           "closedDays",
           "courts",
           "schedule"
@@ -1235,6 +1236,10 @@
           },
           "name": {
             "type": "string"
+          },
+          "revenue": {
+            "type": "number",
+            "format": "double"
           },
           "closedDays": {
             "type": "array",
@@ -1254,6 +1259,40 @@
             "items": {
               "$ref": "#/components/schemas/PlannedDayResponse"
             }
+          }
+        }
+      },
+      "SiteResponse": {
+        "required": [
+          "id",
+          "name",
+          "revenue",
+          "closedDays",
+          "courtsCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "revenue": {
+            "type": "number",
+            "format": "double"
+          },
+          "closedDays": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "courtsCount": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/SiteManagement.MigrationService/DataSeeder.cs
+++ b/SiteManagement.MigrationService/DataSeeder.cs
@@ -64,28 +64,31 @@ public class DataSeeder(
 
         var sites = new[]
         {
-            new Site
-            {
-                Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
-                Name = "Central Sports Complex",
-                ClosedDays = [
-                    new DateOnly(currentYear, 1, 1),
-                    new DateOnly(currentYear, 12, 25)
-                ]
-            },
-            new Site
-            {
-                Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
-                Name = "North Campus Tennis Center",
-                ClosedDays = []
-            },
-            new Site
-            {
-                Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
-                Name = "Riverside Athletic Club",
-                ClosedDays = [new DateOnly(currentYear, 7, 21)]
-            }
-        };
+        new Site
+        {
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Name = "Central Sports Complex",
+            Revenue = 125000m,
+            ClosedDays = [
+                new DateOnly(currentYear, 1, 1),
+                new DateOnly(currentYear, 12, 25)
+            ]
+        },
+        new Site
+        {
+            Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Name = "North Campus Tennis Center",
+            Revenue = 75000m,
+            ClosedDays = []
+        },
+        new Site
+        {
+            Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Name = "Riverside Athletic Club",
+            Revenue = 95000m,
+            ClosedDays = [new DateOnly(currentYear, 7, 21)]
+        }
+    };
 
         context.Sites.AddRange(sites);
         await context.SaveChangesAsync(cancellationToken);

--- a/SiteManagement.MigrationService/Program.cs
+++ b/SiteManagement.MigrationService/Program.cs
@@ -8,6 +8,7 @@ builder.AddServiceDefaults();
 builder.AddSqlServerDbContext<SiteManagementDbContext>("sitemanagementdb");
 
 builder.Services.AddOptions<SeedingOptions>().BindConfiguration(SeedingOptions.Key);
+builder.Services.AddOptions<MigrationOptions>().BindConfiguration(MigrationOptions.Key);
 
 builder.Services.AddScoped<DataSeeder>();
 

--- a/SiteManagement.MigrationService/appsettings.json
+++ b/SiteManagement.MigrationService/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "Seeding": {
-    "ForceRecreate": true
+    "ForceRecreate": false
+  },
+  "Migration": {
+    "StopAfterExecution": false
   }
 }


### PR DESCRIPTION
Introduced Revenue field to Site entity and database schema. Updated DTOs, mappers, and service methods to include Revenue in both detailed and summary responses. Split Site responses into SiteDetailsResponse and SiteResponse. Adjusted controller endpoints and OpenAPI docs. Enhanced data seeder with sample revenue values. Added migration options and configuration for post-migration behavior.