### PR TITLE
Distinguish SiteResponse (summary) vs SiteDetailsResponse

### DIFF
--- a/ProjetWeb.Frontend/src/app/core/api/site/.openapi-generator/FILES
+++ b/ProjetWeb.Frontend/src/app/core/api/site/.openapi-generator/FILES
@@ -24,6 +24,7 @@ model/page-of-of-site-response.ts
 model/page-request.ts
 model/planned-day-response.ts
 model/problem-details.ts
+model/site-details-response.ts
 model/site-response.ts
 model/sort-descriptor.ts
 model/sort-direction.ts

--- a/ProjetWeb.Frontend/src/app/core/api/site/api/sites.service.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/api/sites.service.ts
@@ -27,6 +27,8 @@ import { PageRequest } from '../model/page-request';
 // @ts-ignore
 import { ProblemDetails } from '../model/problem-details';
 // @ts-ignore
+import { SiteDetailsResponse } from '../model/site-details-response';
+// @ts-ignore
 import { SiteResponse } from '../model/site-response';
 // @ts-ignore
 import { TimeSlotResponse } from '../model/time-slot-response';
@@ -168,9 +170,9 @@ export class SitesService extends BaseService {
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public apiSitesIdGet(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteResponse>;
-    public apiSitesIdGet(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteResponse>>;
-    public apiSitesIdGet(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteResponse>>;
+    public apiSitesIdGet(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDetailsResponse>;
+    public apiSitesIdGet(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDetailsResponse>>;
+    public apiSitesIdGet(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDetailsResponse>>;
     public apiSitesIdGet(id: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
         if (id === null || id === undefined) {
             throw new Error('Required parameter id was null or undefined when calling apiSitesIdGet.');
@@ -205,7 +207,7 @@ export class SitesService extends BaseService {
 
         let localVarPath = `/api/Sites/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}`;
         const { basePath, withCredentials } = this.configuration;
-        return this.httpClient.request<SiteResponse>('get', `${basePath}${localVarPath}`,
+        return this.httpClient.request<SiteDetailsResponse>('get', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,
@@ -226,9 +228,9 @@ export class SitesService extends BaseService {
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteResponse>;
-    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteResponse>>;
-    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteResponse>>;
+    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDetailsResponse>;
+    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDetailsResponse>>;
+    public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDetailsResponse>>;
     public apiSitesIdPut(id: string, updateSiteRequest: UpdateSiteRequest, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
         if (id === null || id === undefined) {
             throw new Error('Required parameter id was null or undefined when calling apiSitesIdPut.');
@@ -277,7 +279,7 @@ export class SitesService extends BaseService {
 
         let localVarPath = `/api/Sites/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}`;
         const { basePath, withCredentials } = this.configuration;
-        return this.httpClient.request<SiteResponse>('put', `${basePath}${localVarPath}`,
+        return this.httpClient.request<SiteDetailsResponse>('put', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 body: updateSiteRequest,
@@ -298,9 +300,9 @@ export class SitesService extends BaseService {
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteResponse>;
-    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteResponse>>;
-    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteResponse>>;
+    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDetailsResponse>;
+    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDetailsResponse>>;
+    public apiSitesPost(createSiteRequest: CreateSiteRequest, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDetailsResponse>>;
     public apiSitesPost(createSiteRequest: CreateSiteRequest, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
         if (createSiteRequest === null || createSiteRequest === undefined) {
             throw new Error('Required parameter createSiteRequest was null or undefined when calling apiSitesPost.');
@@ -346,7 +348,7 @@ export class SitesService extends BaseService {
 
         let localVarPath = `/api/Sites`;
         const { basePath, withCredentials } = this.configuration;
-        return this.httpClient.request<SiteResponse>('post', `${basePath}${localVarPath}`,
+        return this.httpClient.request<SiteDetailsResponse>('post', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 body: createSiteRequest,

--- a/ProjetWeb.Frontend/src/app/core/api/site/model/models.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/models.ts
@@ -13,6 +13,7 @@ export * from './page-of-of-site-response';
 export * from './page-request';
 export * from './planned-day-response';
 export * from './problem-details';
+export * from './site-details-response';
 export * from './site-response';
 export * from './sort-descriptor';
 export * from './sort-direction';

--- a/ProjetWeb.Frontend/src/app/core/api/site/model/site-details-response.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/site-details-response.ts
@@ -7,13 +7,16 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { CourtResponse } from './court-response';
+import { PlannedDayResponse } from './planned-day-response';
 
 
-export interface SiteResponse { 
+export interface SiteDetailsResponse { 
     id: string;
     name: string;
     revenue: number;
     closedDays: Array<string>;
-    courtsCount: number;
+    courts: Array<CourtResponse>;
+    schedule: Array<PlannedDayResponse>;
 }
 

--- a/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
+++ b/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
@@ -10,7 +10,7 @@ import {
   FilterGroup,
   SortDescriptor,
   BookTimeSlotRequest,
-  TimeSlotResponse
+  TimeSlotResponse, SiteDetailsResponse
 } from '../api/site';
 
 /**
@@ -59,7 +59,7 @@ export class SiteFacadeService {
    * @param id - The UUID of the site
    * @returns Observable of the site response
    */
-  getSiteById(id: string): Observable<SiteResponse> {
+  getSiteById(id: string): Observable<SiteDetailsResponse> {
     return this.sitesService.apiSitesIdGet(id).pipe(
       catchError(error => this.handleError(`Failed to fetch site with ID: ${id}`, error))
     );
@@ -70,7 +70,7 @@ export class SiteFacadeService {
    * @param siteData - The site creation request data
    * @returns Observable of the created site response
    */
-  createSite(siteData: CreateSiteRequest): Observable<SiteResponse> {
+  createSite(siteData: CreateSiteRequest): Observable<SiteDetailsResponse> {
     return this.sitesService.apiSitesPost(siteData).pipe(
       catchError(error => this.handleError('Failed to create site', error))
     );
@@ -82,7 +82,7 @@ export class SiteFacadeService {
    * @param siteData - The site update request data
    * @returns Observable of the updated site response
    */
-  updateSite(id: string, siteData: UpdateSiteRequest): Observable<SiteResponse> {
+  updateSite(id: string, siteData: UpdateSiteRequest): Observable<SiteDetailsResponse> {
     return this.sitesService.apiSitesIdPut(id, siteData).pipe(
       catchError(error => this.handleError(`Failed to update site with ID: ${id}`, error))
     );

--- a/ProjetWeb.Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/sites-list/components/site-list/site-list.html
@@ -12,12 +12,12 @@
 
     <ng-container matColumnDef="courts">
       <th mat-header-cell *matHeaderCellDef>Courts</th>
-      <td mat-cell *matCellDef="let site">{{ site.courts?.length ?? 0 }}</td>
+      <td mat-cell *matCellDef="let site">{{ site.courtsCount ?? 0 }}</td>
     </ng-container>
 
     <ng-container matColumnDef="revenue">
       <th mat-header-cell *matHeaderCellDef>Revenue</th>
-      <td mat-cell *matCellDef="let site">0€</td>
+      <td mat-cell *matCellDef="let site">{{ site.revenue ?? 0 }}€</td>
     </ng-container>
 
     <ng-container matColumnDef="actions">

--- a/ProjetWeb.Frontend/src/app/views/pages/sites-list/services/site-service.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/sites-list/services/site-service.ts
@@ -18,7 +18,7 @@ import {
   PageRequest,
   SiteResponse,
   UpdateSiteRequest,
-  FilterGroup
+  FilterGroup, SiteDetailsResponse
 } from '../../../../core/api/site';
 
 @Injectable({
@@ -94,7 +94,7 @@ export class SiteService {
     );
   }
 
-  getById(id: string): Observable<SiteResponse | null> {
+  getById(id: string): Observable<SiteDetailsResponse | null> {
     return this.siteFacade.getSiteById(id).pipe(
       catchError(error => {
         console.error(`Failed to fetch site with ID: ${id}`, error);
@@ -103,7 +103,7 @@ export class SiteService {
     );
   }
 
-  update(siteId: string, updateRequest: UpdateSiteRequest): Observable<SiteResponse> {
+  update(siteId: string, updateRequest: UpdateSiteRequest): Observable<SiteDetailsResponse> {
     return this.siteFacade.updateSite(siteId, updateRequest).pipe(
       map(updated => {
         this.refresh();


### PR DESCRIPTION
Introduce SiteDetailsResponse for detailed site data (courts, schedule) and update API, facade, and service layers to use it for single-site operations. Simplify SiteResponse to summary fields only and update UI and references accordingly. Improves type safety and aligns models with backend API.