### PR TITLE
Opening Hours: Add editable schedule config UI & API

### DIFF
--- a/ProjetWeb.Frontend/src/app/core/api/site/model/create-planned-day-request.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/create-planned-day-request.ts
@@ -13,7 +13,7 @@ import { DayOfWeek } from './day-of-week';
 export interface CreatePlannedDayRequest { 
     dayOfWeek: DayOfWeek;
     numberOfTimeSlots: number;
-    startTime: string;
+    startTime: string | null;
 }
 
 

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
@@ -177,95 +177,102 @@
 
     <!-- Schedule Tab -->
     <mat-tab label="Schedule">
-      <div class="p-4 flex flex-col gap-4 w-full">
-        <ng-container *ngIf="scheduleData$ | async as scheduleData">
-          <ng-container *ngIf="scheduleData.rows.length; else noSchedule">
-            <!-- Mobile-first: Info card -->
-            <mat-card class="md:hidden">
-              <mat-card-content class="text-sm text-gray-600">
-                <mat-icon class="text-gray-500 text-base align-middle mr-1">info</mat-icon>
-                Scroll horizontally to view all days
-              </mat-card-content>
-            </mat-card>
-
-            <!-- Schedule table with horizontal scroll on mobile -->
-            <div class="overflow-x-auto">
-              <table mat-table [dataSource]="scheduleData.rows" class="w-full min-w-[800px]">
-                <!-- Slot Number Column -->
-                <ng-container matColumnDef="slotNumber">
-                  <th mat-header-cell *matHeaderCellDef class="bg-gray-50 font-semibold text-center px-2 py-3">
-                    Slot #
-                  </th>
-                  <td mat-cell *matCellDef="let row" class="bg-gray-50 font-medium text-center px-2 py-2">
-                    {{ row.slotNumber }}
-                  </td>
-                </ng-container>
-
-                <!-- Day Columns -->
-                <ng-container *ngFor="let day of daysOfWeek" [matColumnDef]="day">
-                  <th mat-header-cell *matHeaderCellDef class="bg-gray-50 font-semibold text-center px-2 py-3">
-                    <div class="flex flex-col">
-                      <span class="hidden md:inline">{{ day }}</span>
-                      <span class="md:hidden">{{ day.substring(0, 3) }}</span>
-                    </div>
-                  </th>
-                  <td mat-cell *matCellDef="let row" class="text-center px-2 py-2">
-                    <ng-container *ngIf="getTimeSlot(row, day) as slot; else emptySlot">
-                      <div class="flex flex-col gap-1 text-xs">
-                        <span class="font-medium">{{ formatTime(slot.dateTime) }}</span>
-                        <span
-                          class="px-2 py-1 rounded text-xs font-medium"
-                          [ngClass]="getBookStateColor(slot.bookState)"
-                          [matTooltip]="'Court ID: ' + slot.courtId + ' | Week: ' + slot.weekNumber"
-                        >
-                          {{ slot.bookState }}
-                        </span>
-                      </div>
-                    </ng-container>
-                    <ng-template #emptySlot>
-                      <span class="text-gray-400 text-xs">—</span>
-                    </ng-template>
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="['slotNumber'].concat(daysOfWeek)" class="sticky top-0"></tr>
-                <tr mat-row *matRowDef="let row; columns: ['slotNumber'].concat(daysOfWeek)" class="hover:bg-gray-50"></tr>
-              </table>
+      <div class="p-4 flex flex-col gap-4 max-w-4xl mx-auto">
+        <mat-card>
+          <mat-card-header class="pb-4">
+            <mat-card-title class="text-xl">Opening Hours Configuration</mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <div class="mb-4 text-sm text-gray-600">
+              <mat-icon class="text-gray-500 text-base align-middle mr-1">info</mat-icon>
+              Configure the number of time slots (0-8) and start time for each day. Each time slot is 105 minutes.
             </div>
 
-            <!-- Legend -->
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title class="text-base">Legend</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
-                <div class="flex flex-wrap gap-3 text-xs">
-                  <div class="flex items-center gap-1">
-                    <span class="px-2 py-1 rounded bg-green-100 text-green-800">Available</span>
-                  </div>
-                  <div class="flex items-center gap-1">
-                    <span class="px-2 py-1 rounded bg-red-100 text-red-800">Booked</span>
-                  </div>
-                  <div class="flex items-center gap-1">
-                    <span class="px-2 py-1 rounded bg-gray-100 text-gray-800">Unavailable</span>
-                  </div>
-                </div>
-                <p class="text-xs text-gray-600 mt-2">
-                  Each time slot is 105 minutes. Hover over a slot to see court and week details.
-                </p>
-              </mat-card-content>
-            </mat-card>
-          </ng-container>
+            <!-- Table -->
+            <div class="hidden md:block overflow-x-auto">
+              <table class="w-full border-collapse">
+                <thead>
+                  <tr class="border-b-2 border-gray-300">
+                    <th class="text-left p-3 font-semibold">Day</th>
+                    <th class="text-left p-3 font-semibold">Start Time</th>
+                    <th class="text-left p-3 font-semibold">Time Slots</th>
+                    <th class="text-left p-3 font-semibold">Total Duration</th>
+                  </tr>
+                </thead>
+                <tbody [formArray]="scheduleForm">
+                  <ng-container *ngFor="let day of daysOfWeek; let i = index">
+                    <tr class="border-b border-gray-200 hover:bg-gray-50" [formGroupName]="i">
+                      <td class="p-3 font-medium">{{ getDayName(day) }}</td>
+                      <td class="p-3">
+                        <ng-container *ngIf="scheduleEditMode(); else viewStartTime">
+                          <input
+                            type="time"
+                            formControlName="startTime"
+                            class="border border-gray-300 rounded px-3 py-2 w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          />
+                        </ng-container>
+                        <ng-template #viewStartTime>
+                          <span>{{ scheduleForm.at(i).value.startTime }}</span>
+                        </ng-template>
+                      </td>
+                      <td class="p-3">
+                        <ng-container *ngIf="scheduleEditMode(); else viewTimeSlots">
+                          <input
+                            type="number"
+                            formControlName="numberOfTimeSlots"
+                            min="0"
+                            max="8"
+                            class="border border-gray-300 rounded px-3 py-2 w-20 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          />
+                          <mat-error *ngIf="scheduleForm.at(i).get('numberOfTimeSlots')?.touched && scheduleForm.at(i).get('numberOfTimeSlots')?.invalid" class="text-xs text-red-600 mt-1">
+                            Must be between 0 and 8
+                          </mat-error>
+                        </ng-container>
+                        <ng-template #viewTimeSlots>
+                          <span>{{ scheduleForm.at(i).value.numberOfTimeSlots }}</span>
+                        </ng-template>
+                      </td>
+                      <td class="p-3 text-sm text-gray-600">
+                        {{ (scheduleForm.at(i).value?.numberOfTimeSlots ?? 0) * 105 }} minutes
+                      </td>
+                    </tr>
+                  </ng-container>
+                </tbody>
+              </table>
+            </div>
+          </mat-card-content>
 
-          <ng-template #noSchedule>
-            <mat-card>
-              <mat-card-content class="text-center py-8">
-                <mat-icon class="text-gray-400 text-5xl w-12 h-12 mx-auto mb-4">calendar_today</mat-icon>
-                <p class="text-gray-600 text-sm">No schedule configured for this site</p>
-              </mat-card-content>
-            </mat-card>
-          </ng-template>
-        </ng-container>
+          <mat-card-actions class="flex justify-end gap-2 pt-4">
+            <ng-container *ngIf="!scheduleEditMode(); else scheduleEditActions">
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="startScheduleEdit()"
+              >
+                <mat-icon class="mr-1">edit</mat-icon>
+                Edit Schedule
+              </button>
+            </ng-container>
+            <ng-template #scheduleEditActions>
+              <button
+                mat-button
+                (click)="cancelScheduleEdit()"
+                [disabled]="saving()"
+              >
+                Cancel
+              </button>
+              <button
+                mat-raised-button
+                color="primary"
+                (click)="saveSchedule(site)"
+                [disabled]="!scheduleForm.valid || saving()"
+              >
+                <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20" class="inline-block mr-2"></mat-progress-spinner>
+                Save Schedule
+              </button>
+            </ng-template>
+          </mat-card-actions>
+        </mat-card>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
@@ -199,9 +199,9 @@
                     <th class="text-left p-3 font-semibold">Total Duration</th>
                   </tr>
                 </thead>
-                <tbody [formArray]="scheduleForm">
+                <tbody>
                   <ng-container *ngFor="let day of daysOfWeek; let i = index">
-                    <tr class="border-b border-gray-200 hover:bg-gray-50" [formGroupName]="i">
+                    <tr class="border-b border-gray-200 hover:bg-gray-50" [formGroup]="scheduleForm.at(i)">
                       <td class="p-3 font-medium">{{ getDayName(day) }}</td>
                       <td class="p-3">
                         <ng-container *ngIf="scheduleEditMode(); else viewStartTime">

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
@@ -103,7 +103,7 @@ export class SiteDetails {
   );
 
   readonly futureBookings$ = this.site$.pipe(
-    map(site => site?.schedule?.flatMap((d: any) => d.timeSlots) ?? [])
+    map(site => site?.schedule?.flatMap(d => d.timeSlots) ?? [])
   );
 
   // Days of the week for schedule configuration
@@ -179,7 +179,7 @@ export class SiteDetails {
     revenue: number;
     closedDays: Date[] | string[];
     courts: CourtResponse[];
-    schedule: any[];
+    schedule: PlannedDayResponse[];
   }): void {
     if (!this.form.valid) {
       this.form.markAllAsTouched();

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@a
 import { AsyncPipe, CurrencyPipe, DatePipe, NgClass, NgForOf, NgIf } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import {catchError, map, of, shareReplay, switchMap, take, tap} from 'rxjs';
+import { catchError, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -14,16 +14,12 @@ import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTabsModule } from '@angular/material/tabs';
-import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { SiteService } from '../../../sites-list/services/site-service';
 import {
   UpdateSiteRequest,
   DayOfWeek,
-  PlannedDayResponse,
-  TimeSlotResponse,
-  CourtResponse
+  CourtResponse, PlannedDayResponse
 } from '../../../../../core/api/site';
 import { SiteDetailsResponse } from '../../../../../core/api/site/model/model-override';
 
@@ -48,8 +44,6 @@ import { SiteDetailsResponse } from '../../../../../core/api/site/model/model-ov
     MatInputModule,
     MatChipsModule,
     MatProgressSpinnerModule,
-    MatTableModule,
-    MatTooltipModule,
   ],
   templateUrl: './site-details.html',
   styleUrl: './site-details.css',
@@ -92,11 +86,12 @@ export class SiteDetails {
           {
             name: site.name ?? '',
             revenue: site.revenue ?? 0,
-            closedDays: (site.closedDays ?? []).map(d => d.toISOString().split('T')[0]).join(', '),
-            courts: (site.courts ?? []).map(c => String(c.number)).join(', '),
+            closedDays: (site.closedDays ?? []).map((d: Date) => d.toISOString().split('T')[0]).join(', '),
+            courts: (site.courts ?? []).map((c: CourtResponse) => String(c.number)).join(', '),
           },
           { emitEvent: false }
         );
+        this.initializeScheduleForm(site);
       }
     }),
     catchError(err => {
@@ -108,10 +103,10 @@ export class SiteDetails {
   );
 
   readonly futureBookings$ = this.site$.pipe(
-    map(site => site?.schedule?.flatMap(d => d.timeSlots) ?? [])//.filter(d => d.d).bookings?.filter(b => new Date(b.startTime) > new Date()) ?? [])
+    map(site => site?.schedule?.flatMap((d: any) => d.timeSlots) ?? [])
   );
 
-  // Schedule table data
+  // Days of the week for schedule configuration
   readonly daysOfWeek: DayOfWeek[] = [
     DayOfWeek.Monday,
     DayOfWeek.Tuesday,
@@ -122,43 +117,17 @@ export class SiteDetails {
     DayOfWeek.Sunday,
   ];
 
-  readonly scheduleData$ = this.site$.pipe(
-    map(site => {
-      if (!site?.schedule?.length) {
-        return { rows: [], maxTimeSlots: 0 };
-      }
-
-      // Since there are always 7 planned days (one per day of week), create a map
-      const dayMap = new Map<DayOfWeek, PlannedDayResponse>();
-      site.schedule.forEach(pd => {
-        dayMap.set(pd.dayOfWeek, pd);
-      });
-
-      // Find the maximum number of time slots across all days
-      const maxTimeSlots = Math.max(...site.schedule.map(pd => pd.numberOfTimeSlots), 0);
-
-      // Build rows: each row represents a time slot number (0 to maxTimeSlots - 1)
-      const rows: ScheduleRow[] = [];
-      for (let slotIndex = 0; slotIndex < maxTimeSlots; slotIndex++) {
-        const row: ScheduleRow = {
-          slotNumber: slotIndex + 1,
-          slots: {}
-        };
-
-        // For each day of the week, get the corresponding time slot
-        this.daysOfWeek.forEach(day => {
-          const plannedDay = dayMap.get(day);
-          if (plannedDay && slotIndex < plannedDay.timeSlots.length) {
-            row.slots[day] = plannedDay.timeSlots[slotIndex];
-          }
-        });
-
-        rows.push(row);
-      }
-
-      return { rows, maxTimeSlots };
-    })
+  // Schedule form for editing opening hours configuration
+  readonly scheduleForm = this.fb.array(
+    this.daysOfWeek.map(() =>
+      this.fb.group({
+        numberOfTimeSlots: this.fb.control<number>(0, [Validators.required, Validators.min(0), Validators.max(8)]),
+        startTime: this.fb.control<string>('08:00')
+      })
+    )
   );
+
+  readonly scheduleEditMode = signal(false);
 
   readonly form = this.fb.nonNullable.group({
     name: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(2)]),
@@ -194,8 +163,8 @@ export class SiteDetails {
       this.form.reset({
         name: site.name ?? '',
         revenue: site.revenue ?? 0,
-        closedDays: (site.closedDays ?? []).map(d => d.toISOString().split('T')[0]).join(', '),
-        courts: (site.courts ?? []).map(c => String(c.number)).join(', '),
+        closedDays: (site.closedDays ?? []).map((d: Date) => d.toISOString().split('T')[0]).join(', '),
+        courts: (site.courts ?? []).map((c: CourtResponse) => String(c.number)).join(', '),
       });
     })).subscribe({ complete: () => {} });
   }
@@ -210,7 +179,7 @@ export class SiteDetails {
     revenue: number;
     closedDays: Date[] | string[];
     courts: CourtResponse[];
-    schedule: PlannedDayResponse[];
+    schedule: any[];
   }): void {
     if (!this.form.valid) {
       this.form.markAllAsTouched();
@@ -267,10 +236,6 @@ export class SiteDetails {
     return courts.find(c => c.id === courtId)?.number;
   }
 
-  getTimeSlot(row: ScheduleRow, day: DayOfWeek): TimeSlotResponse | undefined {
-    return row.slots[day];
-  }
-
   formatTime(dateTime: string): string {
     const date = new Date(dateTime);
     return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
@@ -288,9 +253,102 @@ export class SiteDetails {
         return 'bg-blue-100 text-blue-800';
     }
   }
-}
 
-interface ScheduleRow {
-  slotNumber: number;
-  slots: Partial<Record<DayOfWeek, TimeSlotResponse>>;
+  // Schedule management methods
+  private initializeScheduleForm(site: SiteDetailsResponse | null): void {
+    if (!site?.schedule?.length) {
+      return;
+    }
+
+    const dayMap = new Map<DayOfWeek, PlannedDayResponse>();
+    site.schedule.forEach(pd => dayMap.set(pd.dayOfWeek, pd));
+
+    this.daysOfWeek.forEach((day, index) => {
+      const plannedDay = dayMap.get(day);
+      if (plannedDay) {
+        this.scheduleForm.at(index).patchValue({
+          numberOfTimeSlots: plannedDay.numberOfTimeSlots,
+          startTime: plannedDay.startTime
+        }, { emitEvent: false });
+      }
+    });
+  }
+
+  startScheduleEdit(): void {
+    this.scheduleEditMode.set(true);
+    this.scheduleForm.markAsPristine();
+  }
+
+  cancelScheduleEdit(): void {
+    this.scheduleEditMode.set(false);
+    this.site$.pipe(
+      take(1),
+      tap(site => this.initializeScheduleForm(site))
+    ).subscribe();
+  }
+
+  saveSchedule(site: {
+    id: string;
+    name: string;
+    revenue: number;
+    closedDays: Date[] | string[];
+    courts: CourtResponse[];
+    schedule: any[];
+  }): void {
+    if (!this.scheduleForm.valid) {
+      this.scheduleForm.markAllAsTouched();
+      return;
+    }
+
+    const updated: UpdateSiteRequest = {
+      name: site.name,
+      closedDays: Array.isArray(site.closedDays) ?
+        site.closedDays.map(d => d instanceof Date ? d.toISOString() : d) :
+        [],
+      courts: site.courts.map(c => ({ number: c.number })),
+      schedule: this.daysOfWeek.map((day, index) => {
+        const formValue = this.scheduleForm.at(index).value;
+        return {
+          dayOfWeek: day,
+          numberOfTimeSlots: formValue.numberOfTimeSlots ?? 0,
+          startTime: formValue.startTime ?? null
+        };
+      })
+    };
+
+    this.saving.set(true);
+
+    this.id$.pipe(
+      take(1),
+      switchMap(id => {
+        if (!id) {
+          this.saving.set(false);
+          return of(null);
+        }
+        return this.siteService.update(id, updated);
+      }),
+      tap(() => {
+        this.saving.set(false);
+        this.scheduleEditMode.set(false);
+      }),
+      catchError(err => {
+        console.error('Failed to save schedule', err);
+        this.saving.set(false);
+        return of(null);
+      })
+    ).subscribe();
+  }
+
+  getDayName(day: DayOfWeek): string {
+    const names: Record<DayOfWeek, string> = {
+      [DayOfWeek.Monday]: 'Monday',
+      [DayOfWeek.Tuesday]: 'Tuesday',
+      [DayOfWeek.Wednesday]: 'Wednesday',
+      [DayOfWeek.Thursday]: 'Thursday',
+      [DayOfWeek.Friday]: 'Friday',
+      [DayOfWeek.Saturday]: 'Saturday',
+      [DayOfWeek.Sunday]: 'Sunday'
+    };
+    return names[day];
+  }
 }

--- a/SiteManagement.API/BL/Models/CreatePlannedDayRequest.cs
+++ b/SiteManagement.API/BL/Models/CreatePlannedDayRequest.cs
@@ -5,5 +5,5 @@ namespace SiteManagement.API.BL.Models;
 public record CreatePlannedDayRequest(
     DayOfWeek DayOfWeek,
     int NumberOfTimeSlots,
-    string StartTime
+    string? StartTime
 );

--- a/SiteManagement.API/BL/Models/CreateSiteRequest.cs
+++ b/SiteManagement.API/BL/Models/CreateSiteRequest.cs
@@ -3,26 +3,10 @@ using System.ComponentModel.DataAnnotations;
 namespace SiteManagement.API.BL.Models;
 
 public record CreateSiteRequest(
-    [Required]
-    [StringLength(200, MinimumLength = 1)]
     string Name,
-
-    IReadOnlyCollection<DateOnly>? ClosedDays,
-
+    IReadOnlyCollection<DateTime>? ClosedDays,
     IReadOnlyCollection<CreateCourtRequest>? Courts,
-
-    [Required]
-    [MinLength(7, ErrorMessage = "Schedule must contain exactly 7 days (one for each day of the week)")]
-    [MaxLength(7, ErrorMessage = "Schedule must contain exactly 7 days (one for each day of the week)")]
     IReadOnlyCollection<CreatePlannedDayRequest> Schedule
 )
 {
-    // Custom validation to ensure all 7 days of week are present
-    public bool HasAllDaysOfWeek()
-    {
-        if (Schedule.Count != 7) return false;
-
-        var distinctDays = Schedule.Select(s => s.DayOfWeek).Distinct().Count();
-        return distinctDays == 7;
-    }
 };

--- a/SiteManagement.API/BL/Models/UpdateSiteRequest.cs
+++ b/SiteManagement.API/BL/Models/UpdateSiteRequest.cs
@@ -7,7 +7,7 @@ public record UpdateSiteRequest(
     [StringLength(200, MinimumLength = 1)]
     string Name,
 
-    IReadOnlyCollection<DateOnly>? ClosedDays,
+    IReadOnlyCollection<DateTime>? ClosedDays,
 
     IReadOnlyCollection<CreateCourtRequest>? Courts,
 

--- a/SiteManagement.API/BL/Models/Validators/UpdateSiteRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/UpdateSiteRequestValidator.cs
@@ -22,7 +22,7 @@ public class UpdateSiteRequestValidator : AbstractValidator<UpdateSiteRequest>
                     .IsInEnum();
                     
                 schedule.RuleFor(s => s.NumberOfTimeSlots)
-                    .GreaterThan(0)
+                    .GreaterThanOrEqualTo(0)
                     .LessThanOrEqualTo(8);
             });
 

--- a/SiteManagement.API/BL/Services/SiteService.cs
+++ b/SiteManagement.API/BL/Services/SiteService.cs
@@ -115,7 +115,7 @@ public class SiteService(
         }
 
         site.Name = request.Name;
-        site.ClosedDays = request.ClosedDays?.ToHashSet() ?? [];
+        site.ClosedDays = [.. request.ClosedDays?.Select(DateOnly.FromDateTime) ?? []];
 
         // Update courts using navigation property
         var existingCourtNumbers = site.Courts.Select(c => c.Number).ToHashSet();
@@ -161,6 +161,7 @@ public class SiteService(
             {
                 // Update existing planned day (only NumberOfTimeSplots can change)
                 existingPlannedDay.NumberOfTimeSlots = scheduleRequest.NumberOfTimeSlots;
+                existingPlannedDay.StartTime = TimeOnly.Parse(scheduleRequest.StartTime??"00:00"); //todo: change entity to be nullable
 
                 logger.LogDebug(
                     "Updated PlannedDay for {DayOfWeek} on site {SiteId}: NumberOfTimeSplots = {NumberOfTimeSplots}",

--- a/SiteManagement.API/Controllers/SitesController.cs
+++ b/SiteManagement.API/Controllers/SitesController.cs
@@ -6,6 +6,7 @@ using ToolBox.EntityFramework.Filters;
 
 namespace SiteManagement.API.Controllers;
 
+[AllowAnonymous]
 [ApiController]
 [Route("api/[controller]")]
 public class SitesController(ISiteService siteService) : ControllerBase

--- a/SiteManagement.API/Controllers/SitesController.cs
+++ b/SiteManagement.API/Controllers/SitesController.cs
@@ -6,7 +6,6 @@ using ToolBox.EntityFramework.Filters;
 
 namespace SiteManagement.API.Controllers;
 
-[AllowAnonymous]
 [ApiController]
 [Route("api/[controller]")]
 public class SitesController(ISiteService siteService) : ControllerBase

--- a/SiteManagement.API/SiteManagement.API.json
+++ b/SiteManagement.API/SiteManagement.API.json
@@ -1024,7 +1024,7 @@
             ],
             "items": {
               "type": "string",
-              "format": "date"
+              "format": "date-time"
             }
           },
           "courts": {

--- a/SiteManagement.API/SiteManagement.API.json
+++ b/SiteManagement.API/SiteManagement.API.json
@@ -998,7 +998,10 @@
             "format": "int32"
           },
           "startTime": {
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -1377,7 +1380,7 @@
             ],
             "items": {
               "type": "string",
-              "format": "date"
+              "format": "date-time"
             }
           },
           "courts": {


### PR DESCRIPTION
Replace old schedule table with a new "Opening Hours Configuration" UI for editing number of time slots and start time per day. Update Angular forms and component logic to support schedule editing, validation, and save/cancel actions. Refactor backend API models to allow nullable startTime and use DateTime for closedDays. Update backend service and OpenAPI schema accordingly. Remove unused code related to old schedule table. Mark SitesController as [AllowAnonymous].