### PR TITLE
Add independent site schedule update API and UI

### DIFF
--- a/ProjetWeb.Frontend/package-lock.json
+++ b/ProjetWeb.Frontend/package-lock.json
@@ -427,6 +427,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.0.5.tgz",
       "integrity": "sha512-yO/IRYEZ5wJkpwg3GT3b6RST4pqNFTAhuyPdEdLcE81cs283K3aKOsCYh2xUR3bR4WxBh2kBPSJ31AFZyJXbSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -478,6 +479,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.5.tgz",
       "integrity": "sha512-/ZI11F6Wxr8TZRVO4O7pmhBJ9YxDg9mvA76e0PiivmqZggM02HY0y3XPMP3hAOe4K+PfaVBgMAu3P9t32klzfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -494,6 +496,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.5.tgz",
       "integrity": "sha512-92sv9pVm9o/8KfPM7T8j5VQmTaSOqmIajrJF8evXE2dNJcwkBpVtzZUqDzr23AV3vg94C7eYU64i8qrsmJ+cYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -507,6 +510,7 @@
       "integrity": "sha512-45sFKqt+badXl6Ab2XsxuOsdi0BbIZgcc9TdwmFPdXMNfcSUYDcPiOA0l1iPwDIZiu4VyqzepMfnHB9IwCatgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -539,6 +543,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.5.tgz",
       "integrity": "sha512-HFXfO5YsBVM+IEaU8h3DZSxO98yDZM2v49NlSVNDzFD3fhnkpTmcgT2NKz9ulIiuV9N376itt+x+NG12sg/+Fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -564,6 +569,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.0.5.tgz",
       "integrity": "sha512-RcmXs/LgKyc7D70xVT+3aK/H2SCFEyuebAiw72Iz1te1Gbql2GDFF6hgEOaNwOUglDg8ogN5MdVif2DbRLD3Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -600,6 +606,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.5.tgz",
       "integrity": "sha512-UVCrqOxFmX6kAG3Y6jqjCWvLoTP7fxeY96AsxTMp1fkBdqbQbEPleWQpwngNimsuUPvf+rA6XOxsqiDmRex5mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -721,6 +728,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1082,6 +1090,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1128,6 +1137,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1844,6 +1854,7 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -2655,6 +2666,7 @@
       "integrity": "sha512-ieqWtipT+VlyDWLz5Rvz0f3E5rXcVAnaAi+D53DEHLjc1kmFxCgZ62qVfTX2vwkywwqNkTNXvBgGR72hYqV//Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -4192,7 +4204,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -4626,6 +4639,7 @@
       "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -4798,6 +4812,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4988,6 +5003,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6088,6 +6104,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7273,6 +7290,7 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7386,6 +7404,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -8699,6 +8718,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8876,7 +8896,8 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9060,6 +9081,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9805,7 +9827,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.0.0",
@@ -9856,6 +9879,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10021,6 +10045,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10580,6 +10605,7 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -11027,6 +11053,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ProjetWeb.Frontend/src/app/core/api/site/.openapi-generator/FILES
+++ b/ProjetWeb.Frontend/src/app/core/api/site/.openapi-generator/FILES
@@ -29,6 +29,7 @@ model/site-response.ts
 model/sort-descriptor.ts
 model/sort-direction.ts
 model/time-slot-response.ts
+model/update-schedule-request.ts
 model/update-site-request.ts
 model/validation-problem-details.ts
 param.ts

--- a/ProjetWeb.Frontend/src/app/core/api/site/api/sites.service.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/api/sites.service.ts
@@ -33,6 +33,8 @@ import { SiteResponse } from '../model/site-response';
 // @ts-ignore
 import { TimeSlotResponse } from '../model/time-slot-response';
 // @ts-ignore
+import { UpdateScheduleRequest } from '../model/update-schedule-request';
+// @ts-ignore
 import { UpdateSiteRequest } from '../model/update-site-request';
 // @ts-ignore
 import { ValidationProblemDetails } from '../model/validation-problem-details';
@@ -283,6 +285,79 @@ export class SitesService extends BaseService {
             {
                 context: localVarHttpContext,
                 body: updateSiteRequest,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint put /api/Sites/{id}/schedule
+     * @param id 
+     * @param updateScheduleRequest 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public apiSitesIdSchedulePut(id: string, updateScheduleRequest: UpdateScheduleRequest, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<SiteDetailsResponse>;
+    public apiSitesIdSchedulePut(id: string, updateScheduleRequest: UpdateScheduleRequest, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<SiteDetailsResponse>>;
+    public apiSitesIdSchedulePut(id: string, updateScheduleRequest: UpdateScheduleRequest, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<SiteDetailsResponse>>;
+    public apiSitesIdSchedulePut(id: string, updateScheduleRequest: UpdateScheduleRequest, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling apiSitesIdSchedulePut.');
+        }
+        if (updateScheduleRequest === null || updateScheduleRequest === undefined) {
+            throw new Error('Required parameter updateScheduleRequest was null or undefined when calling apiSitesIdSchedulePut.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'text/plain',
+            'application/json',
+            'text/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'application/json',
+            'text/json',
+            'application/*+json'
+        ];
+        const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+        if (httpContentTypeSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Content-Type', httpContentTypeSelected);
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/Sites/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}/schedule`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<SiteDetailsResponse>('put', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: updateScheduleRequest,
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/ProjetWeb.Frontend/src/app/core/api/site/model/models.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/models.ts
@@ -18,5 +18,6 @@ export * from './site-response';
 export * from './sort-descriptor';
 export * from './sort-direction';
 export * from './time-slot-response';
+export * from './update-schedule-request';
 export * from './update-site-request';
 export * from './validation-problem-details';

--- a/ProjetWeb.Frontend/src/app/core/api/site/model/planned-day-response.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/planned-day-response.ts
@@ -15,7 +15,7 @@ export interface PlannedDayResponse {
     id: string;
     dayOfWeek: DayOfWeek;
     numberOfTimeSlots: number;
-    startTime: string;
+    startTime: string | null;
     timeSlots: Array<TimeSlotResponse>;
 }
 

--- a/ProjetWeb.Frontend/src/app/core/api/site/model/update-schedule-request.ts
+++ b/ProjetWeb.Frontend/src/app/core/api/site/model/update-schedule-request.ts
@@ -7,12 +7,11 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { CreateCourtRequest } from './create-court-request';
+import { CreatePlannedDayRequest } from './create-planned-day-request';
 
 
-export interface UpdateSiteRequest { 
-    name: string;
-    closedDays: Array<string> | null;
-    courts: Array<CreateCourtRequest> | null;
+export interface UpdateScheduleRequest { 
+    siteId: string;
+    plannedDays: Array<CreatePlannedDayRequest>;
 }
 

--- a/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
+++ b/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
@@ -11,7 +11,7 @@ import {
   FilterGroup,
   SortDescriptor,
   BookTimeSlotRequest,
-  TimeSlotResponse, SitesService,
+  TimeSlotResponse, SitesService, UpdateScheduleRequest,
 } from '../api/site';
 
 /**
@@ -92,6 +92,13 @@ export class SiteFacadeService {
       map(site => this.transformSiteDetails(site)),
 
       catchError(error => this.handleError(`Failed to update site with ID: ${id}`, error))
+    );
+  }
+
+  updateSiteSchedule(siteId: string, updateScheduleRequest: UpdateScheduleRequest){
+    return this.sitesService.apiSitesIdSchedulePut(siteId, updateScheduleRequest).pipe(
+      map(site => this.transformSiteDetails(site)),
+      catchError(error => this.handleError(`Failed to update schedule for site with ID: ${siteId}`, error))
     );
   }
 

--- a/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
+++ b/ProjetWeb.Frontend/src/app/core/services/site-facade.service.ts
@@ -95,7 +95,7 @@ export class SiteFacadeService {
     );
   }
 
-  updateSiteSchedule(siteId: string, updateScheduleRequest: UpdateScheduleRequest){
+  updateSiteSchedule(siteId: string, updateScheduleRequest: UpdateScheduleRequest): Observable<SiteDetailsResponse>{
     return this.sitesService.apiSitesIdSchedulePut(siteId, updateScheduleRequest).pipe(
       map(site => this.transformSiteDetails(site)),
       catchError(error => this.handleError(`Failed to update schedule for site with ID: ${siteId}`, error))

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.css
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.css
@@ -1,0 +1,2 @@
+/* Component-specific styles */
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.html
@@ -1,0 +1,42 @@
+<ng-container *ngIf="bookings().length; else noBookings">
+  <mat-card *ngFor="let booking of bookings()" class="hover:shadow-md transition-shadow">
+    <mat-card-header>
+      <mat-icon mat-card-avatar class="text-primary">event</mat-icon>
+      <mat-card-title class="text-base">
+        Court {{ getCourtNumber(booking.courtId) ?? 'Unknown' }}
+      </mat-card-title>
+      <mat-card-subtitle>
+        {{ booking.dateTime | date:'EEEE, MMM d, y' }}
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="flex flex-col gap-2 text-sm mt-2">
+        <div class="flex items-center gap-2">
+          <mat-icon class="text-gray-500 text-lg w-5 h-5">schedule</mat-icon>
+          <span class="text-gray-600">
+            {{ formatTime(booking.dateTime) }} (Slot {{ booking.timeSlotNumber }})
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span
+            class="px-2 py-1 rounded text-xs font-medium"
+            [ngClass]="getBookStateColor(booking.bookState)"
+          >
+            {{ booking.bookState }}
+          </span>
+          <span class="text-gray-600">Week {{ booking.weekNumber }}</span>
+        </div>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</ng-container>
+
+<ng-template #noBookings>
+  <mat-card>
+    <mat-card-content class="text-center py-8">
+      <mat-icon class="text-gray-400 text-5xl w-12 h-12 mx-auto mb-4">event_busy</mat-icon>
+      <p class="text-gray-600 text-sm">No future bookings scheduled</p>
+    </mat-card-content>
+  </mat-card>
+</ng-template>
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { DatePipe, NgClass, NgForOf, NgIf } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/bookings-tab/bookings-tab.component.ts
@@ -1,0 +1,58 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { DatePipe, NgClass, NgForOf, NgIf } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { CourtResponse } from '../../../../../core/api/site';
+
+export interface TimeSlotBooking {
+  id: string;
+  courtId: string;
+  timeSlotNumber: number;
+  weekNumber: number;
+  bookState: string;
+  dateTime: string;
+}
+
+@Component({
+  selector: 'app-bookings-tab',
+  standalone: true,
+  imports: [
+    NgIf,
+    NgForOf,
+    NgClass,
+    DatePipe,
+    MatCardModule,
+    MatIconModule,
+  ],
+  templateUrl: './bookings-tab.component.html',
+  styleUrl: './bookings-tab.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BookingsTabComponent {
+  // Inputs
+  readonly bookings = input.required<TimeSlotBooking[]>();
+  readonly courts = input.required<CourtResponse[]>();
+
+  getCourtNumber(courtId: string): number | undefined {
+    return this.courts().find(c => c.id === courtId)?.number;
+  }
+
+  formatTime(dateTime: string): string {
+    const date = new Date(dateTime);
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+  }
+
+  getBookStateColor(state: string): string {
+    switch (state) {
+      case 'Available':
+        return 'bg-green-100 text-green-800';
+      case 'Booked':
+        return 'bg-red-100 text-red-800';
+      case 'Unavailable':
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-blue-100 text-blue-800';
+    }
+  }
+}
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.css
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.css
@@ -1,0 +1,2 @@
+/* Component-specific styles */
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.html
@@ -1,0 +1,96 @@
+<mat-card>
+  <mat-card-header class="pb-4">
+    <mat-card-title class="text-xl">Opening Hours Configuration</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <div class="mb-4 text-sm text-gray-600">
+      <mat-icon class="text-gray-500 text-base align-middle mr-1">info</mat-icon>
+      Configure the number of time slots (0-8) and start time for each day. Each time slot is 105 minutes.
+    </div>
+
+    <!-- Table -->
+    <div class="hidden md:block overflow-x-auto">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b-2 border-gray-300">
+            <th class="text-left p-3 font-semibold">Day</th>
+            <th class="text-left p-3 font-semibold">Start Time</th>
+            <th class="text-left p-3 font-semibold">Time Slots</th>
+            <th class="text-left p-3 font-semibold">Total Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          <ng-container *ngFor="let day of daysOfWeek; let i = index">
+            <tr class="border-b border-gray-200 hover:bg-gray-50" [formGroup]="scheduleForm.at(i)">
+              <td class="p-3 font-medium">{{ getDayName(day) }}</td>
+              <td class="p-3">
+                <ng-container *ngIf="editMode(); else viewStartTime">
+                  <input
+                    type="time"
+                    formControlName="startTime"
+                    class="border border-gray-300 rounded px-3 py-2 w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </ng-container>
+                <ng-template #viewStartTime>
+                  <span>{{ scheduleForm.at(i).value.startTime }}</span>
+                </ng-template>
+              </td>
+              <td class="p-3">
+                <ng-container *ngIf="editMode(); else viewTimeSlots">
+                  <input
+                    type="number"
+                    formControlName="numberOfTimeSlots"
+                    min="0"
+                    max="8"
+                    class="border border-gray-300 rounded px-3 py-2 w-20 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <div *ngIf="scheduleForm.at(i).get('numberOfTimeSlots')?.touched && scheduleForm.at(i).get('numberOfTimeSlots')?.invalid" class="text-xs text-red-600 mt-1">
+                    Must be between 0 and 8
+                  </div>
+                </ng-container>
+                <ng-template #viewTimeSlots>
+                  <span>{{ scheduleForm.at(i).value.numberOfTimeSlots }}</span>
+                </ng-template>
+              </td>
+              <td class="p-3 text-sm text-gray-600">
+                {{ (scheduleForm.at(i).value?.numberOfTimeSlots ?? 0) * 105 }} minutes
+              </td>
+            </tr>
+          </ng-container>
+        </tbody>
+      </table>
+    </div>
+  </mat-card-content>
+
+  <mat-card-actions class="flex justify-end gap-2 pt-4">
+    <ng-container *ngIf="!editMode(); else scheduleEditActions">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="startEdit()"
+      >
+        <mat-icon class="mr-1">edit</mat-icon>
+        Edit Schedule
+      </button>
+    </ng-container>
+    <ng-template #scheduleEditActions>
+      <button
+        mat-button
+        (click)="cancelEdit()"
+        [disabled]="saving()"
+      >
+        Cancel
+      </button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="onSave()"
+        [disabled]="!scheduleForm.valid || saving()"
+      >
+        <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20" class="inline-block mr-2"></mat-progress-spinner>
+        Save Schedule
+      </button>
+    </ng-template>
+  </mat-card-actions>
+</mat-card>
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.ts
@@ -1,0 +1,133 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { NgForOf, NgIf } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { DayOfWeek, PlannedDayResponse } from '../../../../../core/api/site';
+
+export interface ScheduleUpdateData {
+  schedule: Array<{
+    dayOfWeek: DayOfWeek;
+    numberOfTimeSlots: number;
+    startTime: string | null;
+  }>;
+}
+
+@Component({
+  selector: 'app-schedule-tab',
+  standalone: true,
+  imports: [
+    NgIf,
+    NgForOf,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './schedule-tab.component.html',
+  styleUrl: './schedule-tab.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ScheduleTabComponent {
+  private readonly fb = inject(FormBuilder);
+
+  // Inputs
+  readonly schedule = input.required<PlannedDayResponse[]>();
+  readonly saving = input<boolean>(false);
+
+  // Outputs
+  readonly saveSchedule = output<ScheduleUpdateData>();
+
+  readonly editMode = signal(false);
+
+  readonly daysOfWeek: DayOfWeek[] = [
+    DayOfWeek.Monday,
+    DayOfWeek.Tuesday,
+    DayOfWeek.Wednesday,
+    DayOfWeek.Thursday,
+    DayOfWeek.Friday,
+    DayOfWeek.Saturday,
+    DayOfWeek.Sunday,
+  ];
+
+  readonly scheduleForm = this.fb.array(
+    this.daysOfWeek.map(() =>
+      this.fb.group({
+        numberOfTimeSlots: this.fb.control<number>(0, [Validators.required, Validators.min(0), Validators.max(8)]),
+        startTime: this.fb.control<string>('08:00')
+      })
+    )
+  );
+
+  constructor() {
+    // Initialize form when schedule changes
+    effect(() => {
+      const schedule = this.schedule();
+      if (schedule?.length) {
+        this.initializeForm(schedule);
+      }
+    });
+  }
+
+  private initializeForm(schedule: PlannedDayResponse[]): void {
+    const dayMap = new Map<DayOfWeek, PlannedDayResponse>();
+    schedule.forEach(pd => dayMap.set(pd.dayOfWeek, pd));
+
+    this.daysOfWeek.forEach((day, index) => {
+      const plannedDay = dayMap.get(day);
+      if (plannedDay) {
+        this.scheduleForm.at(index).patchValue({
+          numberOfTimeSlots: plannedDay.numberOfTimeSlots,
+          startTime: plannedDay.startTime
+        }, { emitEvent: false });
+      }
+    });
+  }
+
+  startEdit(): void {
+    this.editMode.set(true);
+    this.scheduleForm.markAsPristine();
+  }
+
+  cancelEdit(): void {
+    this.editMode.set(false);
+    this.initializeForm(this.schedule());
+  }
+
+  onSave(): void {
+    if (!this.scheduleForm.valid) {
+      this.scheduleForm.markAllAsTouched();
+      return;
+    }
+
+    const scheduleData: ScheduleUpdateData = {
+      schedule: this.daysOfWeek.map((day, index) => {
+        const formValue = this.scheduleForm.at(index).value;
+        return {
+          dayOfWeek: day,
+          numberOfTimeSlots: formValue.numberOfTimeSlots ?? 0,
+          startTime: formValue.startTime ?? null
+        };
+      })
+    };
+
+    this.saveSchedule.emit(scheduleData);
+  }
+
+  getDayName(day: DayOfWeek): string {
+    const names: Record<DayOfWeek, string> = {
+      [DayOfWeek.Monday]: 'Monday',
+      [DayOfWeek.Tuesday]: 'Tuesday',
+      [DayOfWeek.Wednesday]: 'Wednesday',
+      [DayOfWeek.Thursday]: 'Thursday',
+      [DayOfWeek.Friday]: 'Friday',
+      [DayOfWeek.Saturday]: 'Saturday',
+      [DayOfWeek.Sunday]: 'Sunday'
+    };
+    return names[day];
+  }
+}
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/schedule-tab/schedule-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal } from '@angular/core';
 import { NgForOf, NgIf } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -57,7 +57,8 @@ export class ScheduleTabComponent {
     this.daysOfWeek.map(() =>
       this.fb.group({
         numberOfTimeSlots: this.fb.control<number>(0, [Validators.required, Validators.min(0), Validators.max(8)]),
-        startTime: this.fb.control<string>('08:00')
+        startTime: this.fb.control<string | null>(null)
+
       })
     )
   );

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.css
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.css
@@ -1,0 +1,2 @@
+/* Component-specific styles */
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
@@ -1,0 +1,101 @@
+<!-- View mode -->
+<ng-container *ngIf="!editMode(); else editForm">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title class="text-base">Closed days</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="flex flex-wrap gap-2" *ngIf="site().closedDays.length; else noClosedDays">
+        <mat-chip *ngFor="let d of site().closedDays">{{ d | date:'yyyy-MM-dd' }}</mat-chip>
+      </div>
+      <ng-template #noClosedDays>
+        <span class="text-sm text-gray-600">No closed days configured</span>
+      </ng-template>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title class="text-base">Courts</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="flex flex-wrap gap-2" *ngIf="site().courts.length; else noCourts">
+        <mat-chip *ngFor="let c of site().courts">Court {{ c.number }}</mat-chip>
+      </div>
+      <ng-template #noCourts>
+        <span class="text-sm text-gray-600">No courts configured</span>
+      </ng-template>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title class="text-base">Revenue</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="flex items-baseline gap-2">
+        <span class="text-xl font-semibold">{{ site().revenue | currency:'EUR':'symbol':'1.0-0' }}</span>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</ng-container>
+
+<!-- Edit mode -->
+<ng-template #editForm>
+  <form [formGroup]="form" class="flex flex-col gap-4" (ngSubmit)="onSave()">
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title class="text-base">General</mat-card-title>
+      </mat-card-header>
+      <mat-card-content class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Name</mat-label>
+          <input matInput formControlName="name" placeholder="Site name" />
+          <mat-error *ngIf="form.controls.name.touched && form.controls.name.invalid">
+            Name is required (min 2 chars)
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Revenue</mat-label>
+          <input matInput type="number" formControlName="revenue" />
+          <mat-error *ngIf="form.controls.revenue.touched && form.controls.revenue.invalid">
+            Revenue must be a positive number
+          </mat-error>
+        </mat-form-field>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title class="text-base">Closed days</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Closed dates (YYYY-MM-DD, comma separated)</mat-label>
+          <input matInput formControlName="closedDays" placeholder="2026-01-24, 2026-01-31" />
+        </mat-form-field>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title class="text-base">Courts</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="w-full">
+          <div class="text-xs text-gray-600 mb-1">Courts</div>
+          <p class="text-sm text-gray-800 break-words">
+            {{ form.get('courts')?.value || '—' }}
+          </p>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <div class="flex items-center gap-3">
+      <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20"></mat-progress-spinner>
+      <span *ngIf="saving()" class="text-sm text-gray-600">Saving…</span>
+    </div>
+  </form>
+</ng-template>
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { CurrencyPipe, DatePipe, NgForOf, NgIf } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { CourtResponse } from '../../../../../core/api/site';
+import { SiteDetailsResponse } from '../../../../../core/api/site/model/model-override';
+
+@Component({
+  selector: 'app-site-details-tab',
+  standalone: true,
+  imports: [
+    NgIf,
+    NgForOf,
+    DatePipe,
+    CurrencyPipe,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatChipsModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './site-details-tab.component.html',
+  styleUrl: './site-details-tab.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SiteDetailsTabComponent {
+  private readonly fb = inject(FormBuilder);
+
+  // Inputs
+  readonly site = input.required<SiteDetailsResponse>();
+  readonly editMode = input<boolean>(false);
+  readonly saving = input<boolean>(false);
+
+  // Outputs
+  readonly startEdit = output<void>();
+  readonly cancelEdit = output<void>();
+  readonly save = output<{ name: string; closedDays: Date[] }>();
+
+  readonly form = this.fb.nonNullable.group({
+    name: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(2)]),
+    revenue: this.fb.nonNullable.control({ value: 0, disabled: true }, [Validators.required, Validators.min(0)]),
+    closedDays: this.fb.nonNullable.control(''),
+    courts: this.fb.nonNullable.control({ value: '', disabled: true }),
+  });
+
+  readonly canSave = computed(() => this.editMode() && this.form.valid && !this.saving());
+
+  constructor() {
+    // Initialize form when site changes
+    effect(() => {
+      const site = this.site();
+      if (site) {
+        this.initializeForm(site);
+      }
+    });
+  }
+
+  private initializeForm(site: SiteDetailsResponse): void {
+    this.form.patchValue(
+      {
+        name: site.name ?? '',
+        revenue: site.revenue ?? 0,
+        closedDays: (site.closedDays ?? []).map((d: Date) => d.toISOString().split('T')[0]).join(', '),
+        courts: (site.courts ?? []).map((c: CourtResponse) => String(c.number)).join(', '),
+      },
+      { emitEvent: false }
+    );
+  }
+
+  onStartEdit(): void {
+    this.startEdit.emit();
+    this.form.markAsPristine();
+  }
+
+  onCancelEdit(): void {
+    this.cancelEdit.emit();
+    this.initializeForm(this.site());
+  }
+
+  onSave(): void {
+    if (!this.form.valid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const closedDays = this.splitCsv(this.form.controls.closedDays.value)
+      .map(s => new Date(s))
+      .filter(d => !Number.isNaN(d.getTime()));
+
+    this.save.emit({
+      name: this.form.controls.name.value.trim(),
+      closedDays
+    });
+  }
+
+  private splitCsv(value: string): string[] {
+    return (value ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+  }
+}
+
+

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, output } from '@angular/core';
 import { CurrencyPipe, DatePipe, NgForOf, NgIf } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
@@ -8,121 +8,20 @@
     <span class="ml-2 truncate">{{ site.name }}</span>
 
     <span class="flex-1"></span>
-
-    <ng-container *ngIf="!editMode(); else editActions">
-      <button mat-button (click)="startEdit()">Edit</button>
-    </ng-container>
-
-    <ng-template #editActions>
-      <button mat-button (click)="cancelEdit()" [disabled]="saving()">Cancel</button>
-      <button mat-flat-button color="accent" (click)="save(site)" [disabled]="!canSave()">Save</button>
-    </ng-template>
   </mat-toolbar>
 
   <mat-tab-group class="w-full" mat-stretch-tabs="false" mat-align-tabs="start">
     <!-- Details Tab -->
     <mat-tab label="Details">
       <div class="p-4 flex flex-col gap-4 max-w-3xl mx-auto">
-        <!-- View mode -->
-        <ng-container *ngIf="!editMode(); else editForm">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title class="text-base">Closed days</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-              <div class="flex flex-wrap gap-2" *ngIf="site.closedDays.length; else noClosedDays">
-                <mat-chip *ngFor="let d of site.closedDays">{{ d | date:'yyyy-MM-dd' }}</mat-chip>
-              </div>
-              <ng-template #noClosedDays>
-                <span class="text-sm text-gray-600">No closed days configured</span>
-              </ng-template>
-            </mat-card-content>
-          </mat-card>
-
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title class="text-base">Courts</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-              <div class="flex flex-wrap gap-2" *ngIf="site.courts.length; else noCourts">
-                <mat-chip *ngFor="let c of site.courts">Court {{ c.number }}</mat-chip>
-              </div>
-              <ng-template #noCourts>
-                <span class="text-sm text-gray-600">No courts configured</span>
-              </ng-template>
-            </mat-card-content>
-          </mat-card>
-
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title class="text-base">Revenue</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-              <div class="flex items-baseline gap-2">
-                <span class="text-xl font-semibold">{{ site.revenue | currency:'EUR':'symbol':'1.0-0' }}</span>
-              </div>
-            </mat-card-content>
-          </mat-card>
-        </ng-container>
-
-        <!-- Edit mode -->
-        <ng-template #editForm>
-          <form [formGroup]="form" class="flex flex-col gap-4">
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title class="text-base">General</mat-card-title>
-              </mat-card-header>
-              <mat-card-content class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <mat-form-field appearance="outline" class="w-full">
-                  <mat-label>Name</mat-label>
-                  <input matInput formControlName="name" placeholder="Site name" />
-                  <mat-error *ngIf="form.controls.name.touched && form.controls.name.invalid">
-                    Name is required (min 2 chars)
-                  </mat-error>
-                </mat-form-field>
-
-                <mat-form-field appearance="outline" class="w-full">
-                  <mat-label>Revenue</mat-label>
-                  <input matInput type="number" formControlName="revenue" />
-                  <mat-error *ngIf="form.controls.revenue.touched && form.controls.revenue.invalid">
-                    Revenue must be a positive number
-                  </mat-error>
-                </mat-form-field>
-              </mat-card-content>
-            </mat-card>
-
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title class="text-base">Closed days</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
-                <mat-form-field appearance="outline" class="w-full">
-                  <mat-label>Closed dates (YYYY-MM-DD, comma separated)</mat-label>
-                  <input matInput formControlName="closedDays" placeholder="2026-01-24, 2026-01-31" />
-                </mat-form-field>
-              </mat-card-content>
-            </mat-card>
-
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title class="text-base">Courts</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
-                <div class="w-full">
-                  <div class="text-xs text-gray-600 mb-1">Courts</div>
-                  <p class="text-sm text-gray-800 break-words">
-                    {{ form.get('courts')?.value || '—' }}
-                  </p>
-                </div>
-              </mat-card-content>
-            </mat-card>
-
-            <div class="flex items-center gap-3">
-              <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20"></mat-progress-spinner>
-              <span *ngIf="saving()" class="text-sm text-gray-600">Saving…</span>
-            </div>
-          </form>
-        </ng-template>
+        <app-site-details-tab
+          [site]="site"
+          [editMode]="editMode()"
+          [saving]="saving()"
+          (startEdit)="startEdit()"
+          (cancelEdit)="cancelEdit()"
+          (save)="onDetailsSave($event)"
+        />
       </div>
     </mat-tab>
 
@@ -130,47 +29,10 @@
     <mat-tab label="Bookings">
       <div class="p-4 flex flex-col gap-4 max-w-3xl mx-auto">
         <ng-container *ngIf="futureBookings$ | async as bookings">
-          <ng-container *ngIf="bookings.length; else noBookings">
-            <mat-card *ngFor="let booking of bookings" class="hover:shadow-md transition-shadow">
-              <mat-card-header>
-                <mat-icon mat-card-avatar class="text-primary">event</mat-icon>
-                <mat-card-title class="text-base">
-                  Court {{ getCourtNumber(booking.courtId, site.courts) ?? 'Unknown' }}
-                </mat-card-title>
-                <mat-card-subtitle>
-                  {{ booking.dateTime | date:'EEEE, MMM d, y' }}
-                </mat-card-subtitle>
-              </mat-card-header>
-              <mat-card-content>
-                <div class="flex flex-col gap-2 text-sm mt-2">
-                  <div class="flex items-center gap-2">
-                    <mat-icon class="text-gray-500 text-lg w-5 h-5">schedule</mat-icon>
-                    <span class="text-gray-600">
-                      {{ formatTime(booking.dateTime) }} (Slot {{ booking.timeSlotNumber }})
-                    </span>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <span
-                      class="px-2 py-1 rounded text-xs font-medium"
-                      [ngClass]="getBookStateColor(booking.bookState)"
-                    >
-                      {{ booking.bookState }}
-                    </span>
-                    <span class="text-gray-600">Week {{ booking.weekNumber }}</span>
-                  </div>
-                </div>
-              </mat-card-content>
-            </mat-card>
-          </ng-container>
-
-          <ng-template #noBookings>
-            <mat-card>
-              <mat-card-content class="text-center py-8">
-                <mat-icon class="text-gray-400 text-5xl w-12 h-12 mx-auto mb-4">event_busy</mat-icon>
-                <p class="text-gray-600 text-sm">No future bookings scheduled</p>
-              </mat-card-content>
-            </mat-card>
-          </ng-template>
+          <app-bookings-tab
+            [bookings]="bookings"
+            [courts]="site.courts"
+          />
         </ng-container>
       </div>
     </mat-tab>
@@ -178,101 +40,11 @@
     <!-- Schedule Tab -->
     <mat-tab label="Schedule">
       <div class="p-4 flex flex-col gap-4 max-w-4xl mx-auto">
-        <mat-card>
-          <mat-card-header class="pb-4">
-            <mat-card-title class="text-xl">Opening Hours Configuration</mat-card-title>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="mb-4 text-sm text-gray-600">
-              <mat-icon class="text-gray-500 text-base align-middle mr-1">info</mat-icon>
-              Configure the number of time slots (0-8) and start time for each day. Each time slot is 105 minutes.
-            </div>
-
-            <!-- Table -->
-            <div class="hidden md:block overflow-x-auto">
-              <table class="w-full border-collapse">
-                <thead>
-                  <tr class="border-b-2 border-gray-300">
-                    <th class="text-left p-3 font-semibold">Day</th>
-                    <th class="text-left p-3 font-semibold">Start Time</th>
-                    <th class="text-left p-3 font-semibold">Time Slots</th>
-                    <th class="text-left p-3 font-semibold">Total Duration</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <ng-container *ngFor="let day of daysOfWeek; let i = index">
-                    <tr class="border-b border-gray-200 hover:bg-gray-50" [formGroup]="scheduleForm.at(i)">
-                      <td class="p-3 font-medium">{{ getDayName(day) }}</td>
-                      <td class="p-3">
-                        <ng-container *ngIf="scheduleEditMode(); else viewStartTime">
-                          <input
-                            type="time"
-                            formControlName="startTime"
-                            class="border border-gray-300 rounded px-3 py-2 w-32 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                          />
-                        </ng-container>
-                        <ng-template #viewStartTime>
-                          <span>{{ scheduleForm.at(i).value.startTime }}</span>
-                        </ng-template>
-                      </td>
-                      <td class="p-3">
-                        <ng-container *ngIf="scheduleEditMode(); else viewTimeSlots">
-                          <input
-                            type="number"
-                            formControlName="numberOfTimeSlots"
-                            min="0"
-                            max="8"
-                            class="border border-gray-300 rounded px-3 py-2 w-20 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                          />
-                          <mat-error *ngIf="scheduleForm.at(i).get('numberOfTimeSlots')?.touched && scheduleForm.at(i).get('numberOfTimeSlots')?.invalid" class="text-xs text-red-600 mt-1">
-                            Must be between 0 and 8
-                          </mat-error>
-                        </ng-container>
-                        <ng-template #viewTimeSlots>
-                          <span>{{ scheduleForm.at(i).value.numberOfTimeSlots }}</span>
-                        </ng-template>
-                      </td>
-                      <td class="p-3 text-sm text-gray-600">
-                        {{ (scheduleForm.at(i).value?.numberOfTimeSlots ?? 0) * 105 }} minutes
-                      </td>
-                    </tr>
-                  </ng-container>
-                </tbody>
-              </table>
-            </div>
-          </mat-card-content>
-
-          <mat-card-actions class="flex justify-end gap-2 pt-4">
-            <ng-container *ngIf="!scheduleEditMode(); else scheduleEditActions">
-              <button
-                mat-raised-button
-                color="primary"
-                (click)="startScheduleEdit()"
-              >
-                <mat-icon class="mr-1">edit</mat-icon>
-                Edit Schedule
-              </button>
-            </ng-container>
-            <ng-template #scheduleEditActions>
-              <button
-                mat-button
-                (click)="cancelScheduleEdit()"
-                [disabled]="saving()"
-              >
-                Cancel
-              </button>
-              <button
-                mat-raised-button
-                color="primary"
-                (click)="saveSchedule(site)"
-                [disabled]="!scheduleForm.valid || saving()"
-              >
-                <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20" class="inline-block mr-2"></mat-progress-spinner>
-                Save Schedule
-              </button>
-            </ng-template>
-          </mat-card-actions>
-        </mat-card>
+        <app-schedule-tab
+          [schedule]="site.schedule"
+          [saving]="saving()"
+          (saveSchedule)="onScheduleSave($event)"
+        />
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
@@ -69,7 +69,7 @@ export class SiteDetails {
   );
 
   readonly futureBookings$ = this.site$.pipe(
-    map(site => site?.schedule?.flatMap((d: any) => d.timeSlots) ?? [])
+    map(site => site?.schedule?.flatMap((d) => d.timeSlots) ?? [])
   );
 
   async goBack(): Promise<void> {

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
@@ -1,49 +1,37 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { AsyncPipe, CurrencyPipe, DatePipe, NgClass, NgForOf, NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { AsyncPipe, NgIf } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { catchError, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTabsModule } from '@angular/material/tabs';
 
 import { SiteService } from '../../../sites-list/services/site-service';
-import {
-  UpdateSiteRequest,
-  DayOfWeek,
-  CourtResponse, PlannedDayResponse
-} from '../../../../../core/api/site';
+import { UpdateSiteRequest } from '../../../../../core/api/site';
 import { SiteDetailsResponse } from '../../../../../core/api/site/model/model-override';
+import { SiteDetailsTabComponent } from '../site-details-tab/site-details-tab.component';
+import { BookingsTabComponent } from '../bookings-tab/bookings-tab.component';
+import { ScheduleTabComponent, ScheduleUpdateData } from '../schedule-tab/schedule-tab.component';
 
 @Component({
   selector: 'app-site-details',
   standalone: true,
   imports: [
     NgIf,
-    NgForOf,
-    NgClass,
     AsyncPipe,
-    CurrencyPipe,
-    DatePipe,
-    ReactiveFormsModule,
     MatToolbarModule,
     MatTabsModule,
     MatButtonModule,
     MatIconModule,
     MatCardModule,
-    MatDividerModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatChipsModule,
     MatProgressSpinnerModule,
+    SiteDetailsTabComponent,
+    BookingsTabComponent,
+    ScheduleTabComponent,
   ],
   templateUrl: './site-details.html',
   styleUrl: './site-details.css',
@@ -52,7 +40,6 @@ import { SiteDetailsResponse } from '../../../../../core/api/site/model/model-ov
 export class SiteDetails {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  private readonly fb = inject(FormBuilder);
   private readonly siteService = inject(SiteService);
 
   readonly loading = signal(true);
@@ -60,7 +47,7 @@ export class SiteDetails {
   readonly editMode = signal(false);
 
   readonly id$ = this.route.paramMap.pipe(
-    map(pm => (pm.get('id'))),
+    map(pm => pm.get('id')),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
@@ -70,30 +57,9 @@ export class SiteDetails {
       if (!id) {
         return of<SiteDetailsResponse | null>(null);
       }
-      return this.siteService.getById(id).pipe(
-        map(site => {
-          if (!site) {
-            return null;
-          }
-          return site;
-        })
-      );
+      return this.siteService.getById(id);
     }),
-    tap(site => {
-      this.loading.set(false);
-      if (site) {
-        this.form.patchValue(
-          {
-            name: site.name ?? '',
-            revenue: site.revenue ?? 0,
-            closedDays: (site.closedDays ?? []).map((d: Date) => d.toISOString().split('T')[0]).join(', '),
-            courts: (site.courts ?? []).map((c: CourtResponse) => String(c.number)).join(', '),
-          },
-          { emitEvent: false }
-        );
-        this.initializeScheduleForm(site);
-      }
-    }),
+    tap(() => this.loading.set(false)),
     catchError(err => {
       console.error('Failed to load site details', err);
       this.loading.set(false);
@@ -103,115 +69,46 @@ export class SiteDetails {
   );
 
   readonly futureBookings$ = this.site$.pipe(
-    map(site => site?.schedule?.flatMap(d => d.timeSlots) ?? [])
+    map(site => site?.schedule?.flatMap((d: any) => d.timeSlots) ?? [])
   );
-
-  // Days of the week for schedule configuration
-  readonly daysOfWeek: DayOfWeek[] = [
-    DayOfWeek.Monday,
-    DayOfWeek.Tuesday,
-    DayOfWeek.Wednesday,
-    DayOfWeek.Thursday,
-    DayOfWeek.Friday,
-    DayOfWeek.Saturday,
-    DayOfWeek.Sunday,
-  ];
-
-  // Schedule form for editing opening hours configuration
-  readonly scheduleForm = this.fb.array(
-    this.daysOfWeek.map(() =>
-      this.fb.group({
-        numberOfTimeSlots: this.fb.control<number>(0, [Validators.required, Validators.min(0), Validators.max(8)]),
-        startTime: this.fb.control<string>('08:00')
-      })
-    )
-  );
-
-  readonly scheduleEditMode = signal(false);
-
-  readonly form = this.fb.nonNullable.group({
-    name: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(2)]),
-
-    // Read-only fields (kept in the form for easy binding/display in edit mode).
-    revenue: this.fb.nonNullable.control({ value: 0, disabled: true }, [Validators.required, Validators.min(0)]),
-
-    // Simple mobile-friendly editor for closedDays: comma-separated ISO dates.
-    closedDays: this.fb.nonNullable.control(''),
-
-    // Read-only
-    courts: this.fb.nonNullable.control({ value: '', disabled: true }),
-  });
-
-  readonly canSave = computed(() => this.editMode() && this.form.valid && !this.saving());
-
-  startEdit(): void {
-    this.editMode.set(true);
-    this.form.markAsPristine();
-  }
-
-  cancelEdit(): void {
-    this.editMode.set(false);
-    // Reset form back to latest loaded site values.
-    this.site$.pipe(
-      //The take(1) operator ensures the subscription completes immediately after receiving the first value,
-      // preventing any memory leaks.
-      take(1),
-      tap(site => {
-      if (!site) {
-        return;
-      }
-      this.form.reset({
-        name: site.name ?? '',
-        revenue: site.revenue ?? 0,
-        closedDays: (site.closedDays ?? []).map((d: Date) => d.toISOString().split('T')[0]).join(', '),
-        courts: (site.courts ?? []).map((c: CourtResponse) => String(c.number)).join(', '),
-      });
-    })).subscribe({ complete: () => {} });
-  }
 
   async goBack(): Promise<void> {
     await this.router.navigate(['/sites']);
   }
 
-  save(site: {
-    id: string;
-    name: string;
-    revenue: number;
-    closedDays: Date[] | string[];
-    courts: CourtResponse[];
-    schedule: PlannedDayResponse[];
-  }): void {
-    if (!this.form.valid) {
-      this.form.markAllAsTouched();
-      return;
-    }
+  startEdit(): void {
+    this.editMode.set(true);
+  }
 
-    const closedDays = this.splitCsv(this.form.controls.closedDays.value)
-      .map(s => new Date(s))
-      .filter(d => !Number.isNaN(d.getTime()));
+  cancelEdit(): void {
+    this.editMode.set(false);
+  }
 
-    // Keep schedule and courts unchanged from the original site
-    const updated: UpdateSiteRequest = {
-      name: this.form.controls.name.value.trim(),
-      closedDays: closedDays.map(d => d.toISOString()),
-      courts: site.courts.map(c => ({ number: c.number })),
-      schedule: site.schedule.map(pd => ({
-        dayOfWeek: pd.dayOfWeek,
-        numberOfTimeSlots: pd.numberOfTimeSlots,
-        startTime: pd.startTime
-      }))
-    };
-
-    this.saving.set(true);
-
-    this.id$.pipe(
+  onDetailsSave(data: { name: string; closedDays: Date[] }): void {
+    this.site$.pipe(
       take(1),
-      switchMap(id => {
-        if (!id) {
-          this.saving.set(false);
+      switchMap(site => {
+        if (!site) {
           return of(null);
         }
-        return this.siteService.update(id, updated);
+
+        const updated: UpdateSiteRequest = {
+          name: data.name,
+          closedDays: data.closedDays.map(d => d.toISOString()),
+          courts: site.courts.map(c => ({ number: c.number }))
+        };
+
+        this.saving.set(true);
+        return this.id$.pipe(
+          take(1),
+          switchMap(id => {
+            if (!id) {
+              this.saving.set(false);
+              return of(null);
+            }
+            return this.siteService.update(id, updated);
+          })
+        );
       }),
       tap(() => {
         this.saving.set(false);
@@ -225,130 +122,11 @@ export class SiteDetails {
     ).subscribe();
   }
 
-  private splitCsv(value: string): string[] {
-    return (value ?? '')
-      .split(',')
-      .map(s => s.trim())
-
-  }
-
-  getCourtNumber(courtId: string, courts: CourtResponse[]): number | undefined {
-    return courts.find(c => c.id === courtId)?.number;
-  }
-
-  formatTime(dateTime: string): string {
-    const date = new Date(dateTime);
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
-  }
-
-  getBookStateColor(state: string): string {
-    switch (state) {
-      case 'Available':
-        return 'bg-green-100 text-green-800';
-      case 'Booked':
-        return 'bg-red-100 text-red-800';
-      case 'Unavailable':
-        return 'bg-gray-100 text-gray-800';
-      default:
-        return 'bg-blue-100 text-blue-800';
-    }
-  }
-
-  // Schedule management methods
-  private initializeScheduleForm(site: SiteDetailsResponse | null): void {
-    if (!site?.schedule?.length) {
-      return;
-    }
-
-    const dayMap = new Map<DayOfWeek, PlannedDayResponse>();
-    site.schedule.forEach(pd => dayMap.set(pd.dayOfWeek, pd));
-
-    this.daysOfWeek.forEach((day, index) => {
-      const plannedDay = dayMap.get(day);
-      if (plannedDay) {
-        this.scheduleForm.at(index).patchValue({
-          numberOfTimeSlots: plannedDay.numberOfTimeSlots,
-          startTime: plannedDay.startTime
-        }, { emitEvent: false });
-      }
-    });
-  }
-
-  startScheduleEdit(): void {
-    this.scheduleEditMode.set(true);
-    this.scheduleForm.markAsPristine();
-  }
-
-  cancelScheduleEdit(): void {
-    this.scheduleEditMode.set(false);
-    this.site$.pipe(
-      take(1),
-      tap(site => this.initializeScheduleForm(site))
-    ).subscribe();
-  }
-
-  saveSchedule(site: {
-    id: string;
-    name: string;
-    revenue: number;
-    closedDays: Date[] | string[];
-    courts: CourtResponse[];
-    schedule: any[];
-  }): void {
-    if (!this.scheduleForm.valid) {
-      this.scheduleForm.markAllAsTouched();
-      return;
-    }
-
-    const updated: UpdateSiteRequest = {
-      name: site.name,
-      closedDays: Array.isArray(site.closedDays) ?
-        site.closedDays.map(d => d instanceof Date ? d.toISOString() : d) :
-        [],
-      courts: site.courts.map(c => ({ number: c.number })),
-      schedule: this.daysOfWeek.map((day, index) => {
-        const formValue = this.scheduleForm.at(index).value;
-        return {
-          dayOfWeek: day,
-          numberOfTimeSlots: formValue.numberOfTimeSlots ?? 0,
-          startTime: formValue.startTime ?? null
-        };
-      })
-    };
-
-    this.saving.set(true);
-
-    this.id$.pipe(
-      take(1),
-      switchMap(id => {
-        if (!id) {
-          this.saving.set(false);
-          return of(null);
-        }
-        return this.siteService.update(id, updated);
-      }),
-      tap(() => {
-        this.saving.set(false);
-        this.scheduleEditMode.set(false);
-      }),
-      catchError(err => {
-        console.error('Failed to save schedule', err);
-        this.saving.set(false);
-        return of(null);
-      })
-    ).subscribe();
-  }
-
-  getDayName(day: DayOfWeek): string {
-    const names: Record<DayOfWeek, string> = {
-      [DayOfWeek.Monday]: 'Monday',
-      [DayOfWeek.Tuesday]: 'Tuesday',
-      [DayOfWeek.Wednesday]: 'Wednesday',
-      [DayOfWeek.Thursday]: 'Thursday',
-      [DayOfWeek.Friday]: 'Friday',
-      [DayOfWeek.Saturday]: 'Saturday',
-      [DayOfWeek.Sunday]: 'Sunday'
-    };
-    return names[day];
+  onScheduleSave(data: ScheduleUpdateData): void {
+    // TODO: Implement schedule update API endpoint
+    // For now, just log the data
+    console.log('Schedule save requested:', data);
+    console.warn('Schedule update not yet implemented - API endpoint needed');
   }
 }
+

--- a/ProjetWeb.Frontend/src/app/views/pages/sites-list/services/site-service.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/sites-list/services/site-service.ts
@@ -13,7 +13,13 @@ import {
 } from 'rxjs';
 import {map} from 'rxjs/operators';
 import {SiteFacadeService} from '../../../../core/services/site-facade.service';
-import {FilterGroup, PageOfOfSiteResponse, PageRequest, UpdateSiteRequest} from '../../../../core/api/site';
+import {
+  FilterGroup,
+  PageOfOfSiteResponse,
+  PageRequest,
+  UpdateScheduleRequest,
+  UpdateSiteRequest
+} from '../../../../core/api/site';
 import {SiteDetailsResponse} from '../../../../core/api/site/model/model-override';
 
 @Injectable({
@@ -100,6 +106,14 @@ export class SiteService {
 
   update(siteId: string, updateRequest: UpdateSiteRequest): Observable<SiteDetailsResponse> {
     return this.siteFacade.updateSite(siteId, updateRequest).pipe(
+      map(updated => ({
+        ...updated,
+        closedDays: updated.closedDays?.map(d => new Date(d)) ?? []
+      }))
+    );
+  }
+  updateSchedule(siteId: string, updateScheduleRequest: UpdateScheduleRequest): Observable<SiteDetailsResponse> {
+    return this.siteFacade.updateSiteSchedule(siteId, updateScheduleRequest).pipe(
       map(updated => ({
         ...updated,
         closedDays: updated.closedDays?.map(d => new Date(d)) ?? []

--- a/SiteManagement.API/BL/Models/PlannedDayResponse.cs
+++ b/SiteManagement.API/BL/Models/PlannedDayResponse.cs
@@ -4,6 +4,6 @@ public record PlannedDayResponse(
     Guid Id,
     DayOfWeek DayOfWeek,
     int NumberOfTimeSlots,
-    TimeOnly StartTime,
+    TimeOnly? StartTime,
     IReadOnlyCollection<TimeSlotResponse> TimeSlots
 );

--- a/SiteManagement.API/BL/Models/TimeSlotResponse.cs
+++ b/SiteManagement.API/BL/Models/TimeSlotResponse.cs
@@ -12,8 +12,12 @@ public record TimeSlotResponse(
     DateTime DateTime
 )
 {
-    public static DateTime CalculateDateTime(int weekNumber, int timeSlotNumber, TimeOnly startTime, DayOfWeek dayOfWeek)
+    public static DateTime CalculateDateTime(int weekNumber, int timeSlotNumber, TimeOnly? startTime, DayOfWeek dayOfWeek)
     {
+        if(startTime is null)
+        {
+            return default;
+        }
         var year = ISOWeek.GetWeekOfYear(DateTime.UtcNow);
         
         // Get the first day (Monday) of the specified ISO week
@@ -24,9 +28,9 @@ public record TimeSlotResponse(
         var targetDay = firstDayOfWeek.AddDays(daysFromMonday);
 
         var timeToAdd = (timeSlotNumber - 1) * 105;
-        startTime = startTime.AddMinutes(timeToAdd);
+        startTime = startTime.Value.AddMinutes(timeToAdd);
 
         // Combine date with start time
-        return targetDay.Add(startTime.ToTimeSpan());
+        return targetDay.Add(startTime.Value.ToTimeSpan());
     }
 }

--- a/SiteManagement.API/BL/Models/UpdateScheduleRequest.cs
+++ b/SiteManagement.API/BL/Models/UpdateScheduleRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace SiteManagement.API.BL.Models;
+
+public record UpdateScheduleRequest(
+    Guid SiteId,
+    IEnumerable<CreatePlannedDayRequest> PlannedDays
+    )
+{
+}

--- a/SiteManagement.API/BL/Models/UpdateSiteRequest.cs
+++ b/SiteManagement.API/BL/Models/UpdateSiteRequest.cs
@@ -3,19 +3,8 @@ using System.ComponentModel.DataAnnotations;
 namespace SiteManagement.API.BL.Models;
 
 public record UpdateSiteRequest(
-    [Required]
-    [StringLength(200, MinimumLength = 1)]
     string Name,
-
     IReadOnlyCollection<DateTime>? ClosedDays,
-
-    IReadOnlyCollection<CreateCourtRequest>? Courts,
-
-    [Required]
-    [MinLength(7, ErrorMessage = "Schedule must contain exactly 7 days (one for each day of the week)")]
-    [MaxLength(7, ErrorMessage = "Schedule must contain exactly 7 days (one for each day of the week)")]
-    IReadOnlyCollection<CreatePlannedDayRequest> Schedule
+    IReadOnlyCollection<CreateCourtRequest>? Courts
 )
-{
-
-};
+{ }

--- a/SiteManagement.API/BL/Models/Validators/CreatePlannedDayRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/CreatePlannedDayRequestValidator.cs
@@ -12,20 +12,18 @@ public class CreatePlannedDayRequestValidator : AbstractValidator<CreatePlannedD
             .WithMessage("DayOfWeek must be a valid day of the week.");
 
         RuleFor(x => x.NumberOfTimeSlots)
-            .GreaterThan(0)
+            .GreaterThanOrEqualTo(0)
             .LessThanOrEqualTo(8)
-            .WithMessage("NumberOfTimeSlots must be between 1 and 8.");
+            .WithMessage("NumberOfTimeSlots must be between 0 and 8.");
 
         RuleFor(x => x.StartTime)
-            .NotEmpty()
-            .WithMessage("StartTime is required.")
             .Must(BeValidTimeFormat)
             .WithMessage("StartTime must be in the format 'HH:mm' (e.g., '09:00', '14:30').");
     }
 
-    private static bool BeValidTimeFormat(string startTime)
+    private static bool BeValidTimeFormat(string? startTime)
     {
-        return TimeOnly.TryParseExact(
+        return string.IsNullOrEmpty(startTime) || TimeOnly.TryParseExact(
             startTime,
             "HH:mm",
             CultureInfo.InvariantCulture,

--- a/SiteManagement.API/BL/Models/Validators/CreatePlannedDayRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/CreatePlannedDayRequestValidator.cs
@@ -17,6 +17,8 @@ public class CreatePlannedDayRequestValidator : AbstractValidator<CreatePlannedD
             .WithMessage("NumberOfTimeSlots must be between 0 and 8.");
 
         RuleFor(x => x.StartTime)
+            .Must(time => !string.IsNullOrEmpty(time)).When(y => y.NumberOfTimeSlots> 0)
+            .WithMessage("StartTime is required when NumberOfTimeSlots is greater than 0.")
             .Must(BeValidTimeFormat)
             .WithMessage("StartTime must be in the format 'HH:mm' (e.g., '09:00', '14:30').");
     }

--- a/SiteManagement.API/BL/Models/Validators/UpdateScheduleRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/UpdateScheduleRequestValidator.cs
@@ -8,7 +8,8 @@ public class UpdateScheduleRequestValidator: AbstractValidator<UpdateScheduleReq
     {
         RuleFor(x => x.PlannedDays)
             .NotEmpty()
-            .Must(p => p?.Select(d => d.DayOfWeek).Distinct().Count() == 7)
+            .Must(p => p.Count() == 7 && p.Select(d => d.DayOfWeek).Distinct().Count() == 7)
+
             .WithMessage("Schedule must contain exactly 7 days (one for each day of the week) with no duplicates.");
 
         RuleForEach(x => x.PlannedDays).SetValidator(new CreatePlannedDayRequestValidator());

--- a/SiteManagement.API/BL/Models/Validators/UpdateScheduleRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/UpdateScheduleRequestValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+
+namespace SiteManagement.API.BL.Models.Validators;
+
+public class UpdateScheduleRequestValidator: AbstractValidator<UpdateScheduleRequest>
+{
+    public UpdateScheduleRequestValidator()
+    {
+        RuleFor(x => x.PlannedDays)
+            .NotEmpty()
+            .Must(p => p?.Select(d => d.DayOfWeek).Distinct().Count() == 7)
+            .WithMessage("Schedule must contain exactly 7 days (one for each day of the week) with no duplicates.");
+
+        RuleForEach(x => x.PlannedDays).SetValidator(new CreatePlannedDayRequestValidator());
+    }
+}

--- a/SiteManagement.API/BL/Models/Validators/UpdateSiteRequestValidator.cs
+++ b/SiteManagement.API/BL/Models/Validators/UpdateSiteRequestValidator.cs
@@ -10,22 +10,6 @@ public class UpdateSiteRequestValidator : AbstractValidator<UpdateSiteRequest>
             .NotEmpty()
             .MaximumLength(200);
 
-        RuleFor(x => x.Schedule)
-            .NotEmpty()
-            .Must(schedule => schedule?.Select(s => s.DayOfWeek).Distinct().Count() == 7)
-            .WithMessage("Schedule must contain exactly 7 days (one for each day of the week) with no duplicates.");
-
-        RuleForEach(x => x.Schedule)
-            .ChildRules(schedule =>
-            {
-                schedule.RuleFor(s => s.DayOfWeek)
-                    .IsInEnum();
-                    
-                schedule.RuleFor(s => s.NumberOfTimeSlots)
-                    .GreaterThanOrEqualTo(0)
-                    .LessThanOrEqualTo(8);
-            });
-
         When(x => x.Courts is not null, () =>
         {
             RuleForEach(x => x.Courts)

--- a/SiteManagement.API/BL/Services/Abstractions/ISiteService.cs
+++ b/SiteManagement.API/BL/Services/Abstractions/ISiteService.cs
@@ -12,4 +12,5 @@ public interface ISiteService
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     Task<TimeSlotResponse?> BookTimeSlotAsync(Guid siteId, BookTimeSlotRequest request, CancellationToken cancellationToken = default);
     Task<PageOf<SiteResponse>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default);
+    Task<SiteDetailsResponse?> UpdateSiteScheduleAsync(Guid siteId, UpdateScheduleRequest request, CancellationToken cancellationToken);
 }

--- a/SiteManagement.API/Controllers/SitesController.cs
+++ b/SiteManagement.API/Controllers/SitesController.cs
@@ -72,6 +72,27 @@ public class SitesController(ISiteService siteService) : ControllerBase
         return Ok(site);
     }
 
+    [HttpPut("{id:guid}/schedule")]
+    [ProducesResponseType<SiteDetailsResponse>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ValidationProblemDetails>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateSchedule(Guid id, [FromBody] UpdateScheduleRequest request, CancellationToken cancellationToken)
+    {
+        if (id != request.SiteId)
+        {
+            ModelState.AddModelError(nameof(request.SiteId), "Site ID in the URL must match Site ID in the request body.");
+            return ValidationProblem(ModelState);
+        }
+        var site = await siteService.UpdateSiteScheduleAsync(id, request, cancellationToken);
+        
+        if (site is null)
+        {
+            return NotFound();
+        }
+        return Ok(site);
+    }
+
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status401Unauthorized)]

--- a/SiteManagement.API/DAL/Configurations/PlannedDayConfiguration.cs
+++ b/SiteManagement.API/DAL/Configurations/PlannedDayConfiguration.cs
@@ -22,10 +22,9 @@ public class PlannedDayConfiguration : IEntityTypeConfiguration<PlannedDay>
             .HasMaxLength(2);
 
         builder.Property(pd => pd.StartTime)
-            .IsRequired()
             .HasConversion(
-                v => v.ToString("HH:mm"),
-                v => TimeOnly.ParseExact(v, "HH:mm"));
+                v => v == null ? null : v.Value.ToString("HH:mm"),
+                v => string.IsNullOrEmpty(v) ? null : TimeOnly.ParseExact(v, "HH:mm"));
 
         // Configure relationship with Site (defined in SiteConfiguration)
         // Configure relationship with TimeSlots

--- a/SiteManagement.API/DAL/Entities/PlannedDay.cs
+++ b/SiteManagement.API/DAL/Entities/PlannedDay.cs
@@ -6,7 +6,7 @@ public class PlannedDay
     public Guid SiteId { get; set; }
     public DayOfWeek DayOfWeek { get; set; }
     public int NumberOfTimeSlots { get; set; }
-    public TimeOnly StartTime { get; set; }
+    public TimeOnly? StartTime { get; set; }
 
     // Navigation properties
     public Site Site { get; set; } = null!;

--- a/SiteManagement.API/Migrations/20260214101951_MakeStartTimeNullable.Designer.cs
+++ b/SiteManagement.API/Migrations/20260214101951_MakeStartTimeNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SiteManagement.API.DAL;
 
@@ -11,9 +12,11 @@ using SiteManagement.API.DAL;
 namespace SiteManagement.API.Migrations
 {
     [DbContext(typeof(SiteManagementDbContext))]
-    partial class SiteManagementDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260214101951_MakeStartTimeNullable")]
+    partial class MakeStartTimeNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SiteManagement.API/Migrations/20260214101951_MakeStartTimeNullable.cs
+++ b/SiteManagement.API/Migrations/20260214101951_MakeStartTimeNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SiteManagement.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeStartTimeNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "StartTime",
+                table: "PlannedDays",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "StartTime",
+                table: "PlannedDays",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/SiteManagement.API/SiteManagement.API.json
+++ b/SiteManagement.API/SiteManagement.API.json
@@ -738,6 +738,166 @@
         }
       }
     },
+    "/api/Sites/{id}/schedule": {
+      "put": {
+        "tags": [
+          "Sites"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScheduleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteDetailsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Sites/{siteId}/timeslots/book": {
       "post": {
         "tags": [
@@ -1184,7 +1344,10 @@
             "format": "int32"
           },
           "startTime": {
-            "type": "string",
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "time"
           },
           "timeSlots": {
@@ -1361,12 +1524,30 @@
           }
         }
       },
+      "UpdateScheduleRequest": {
+        "required": [
+          "siteId",
+          "plannedDays"
+        ],
+        "type": "object",
+        "properties": {
+          "siteId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "plannedDays": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreatePlannedDayRequest"
+            }
+          }
+        }
+      },
       "UpdateSiteRequest": {
         "required": [
           "name",
           "closedDays",
-          "courts",
-          "schedule"
+          "courts"
         ],
         "type": "object",
         "properties": {
@@ -1390,12 +1571,6 @@
             ],
             "items": {
               "$ref": "#/components/schemas/CreateCourtRequest"
-            }
-          },
-          "schedule": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CreatePlannedDayRequest"
             }
           }
         }


### PR DESCRIPTION
This commit introduces a new backend API endpoint and frontend UI flow for updating a site's schedule (opening hours) independently from other site details.

- Backend: Adds UpdateScheduleRequest, validator, and PUT /api/Sites/{id}/schedule endpoint. PlannedDay.StartTime is now nullable. Validation allows 0 time slots and null start times.
- Frontend: Adds update-schedule-request model and support in Angular services. Refactors site details page into modular tabs (details, bookings, schedule). Schedule tab provides editable table for opening hours. Details and bookings tabs are also modularized.
- Improves maintainability and user experience by separating schedule editing from general site info.