### PR TITLE
Refactor site details tab: new Angular syntax, UX, API

### DIFF
--- a/ProjetWeb.Frontend/angular.json
+++ b/ProjetWeb.Frontend/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
@@ -103,7 +103,7 @@
     </div>
 
     <div class="flex items-center gap-3">
-      <button mat-raised-button color="primary" type="submit" [disabled]="saving()">
+      <button mat-raised-button color="primary" type="submit" [disabled]="saving() || form.invalid">
         <mat-icon>save</mat-icon>
         Save
       </button>

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.html
@@ -1,16 +1,19 @@
 <!-- View mode -->
-<ng-container *ngIf="!editMode(); else editForm">
+@if (!editMode()) {
   <mat-card>
     <mat-card-header>
       <mat-card-title class="text-base">Closed days</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <div class="flex flex-wrap gap-2" *ngIf="site().closedDays.length; else noClosedDays">
-        <mat-chip *ngFor="let d of site().closedDays">{{ d | date:'yyyy-MM-dd' }}</mat-chip>
-      </div>
-      <ng-template #noClosedDays>
+      @if (site().closedDays.length) {
+        <div class="flex flex-wrap gap-2">
+          @for (d of site().closedDays; track d) {
+            <mat-chip>{{ d | date:'yyyy-MM-dd' }}</mat-chip>
+          }
+        </div>
+      } @else {
         <span class="text-sm text-gray-600">No closed days configured</span>
-      </ng-template>
+      }
     </mat-card-content>
   </mat-card>
 
@@ -19,12 +22,15 @@
       <mat-card-title class="text-base">Courts</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <div class="flex flex-wrap gap-2" *ngIf="site().courts.length; else noCourts">
-        <mat-chip *ngFor="let c of site().courts">Court {{ c.number }}</mat-chip>
-      </div>
-      <ng-template #noCourts>
+      @if (site().courts.length) {
+        <div class="flex flex-wrap gap-2">
+          @for (c of site().courts; track c.number) {
+            <mat-chip>Court {{ c.number }}</mat-chip>
+          }
+        </div>
+      } @else {
         <span class="text-sm text-gray-600">No courts configured</span>
-      </ng-template>
+      }
     </mat-card-content>
   </mat-card>
 
@@ -38,10 +44,15 @@
       </div>
     </mat-card-content>
   </mat-card>
-</ng-container>
 
-<!-- Edit mode -->
-<ng-template #editForm>
+  <div class="flex items-center gap-3 mt-4">
+    <button mat-raised-button color="primary" (click)="startEdit()">
+      <mat-icon>edit</mat-icon>
+      Edit
+    </button>
+  </div>
+} @else {
+  <!-- Edit mode -->
   <form [formGroup]="form" class="flex flex-col gap-4" (ngSubmit)="onSave()">
     <mat-card>
       <mat-card-header>
@@ -51,17 +62,11 @@
         <mat-form-field appearance="outline" class="w-full">
           <mat-label>Name</mat-label>
           <input matInput formControlName="name" placeholder="Site name" />
-          <mat-error *ngIf="form.controls.name.touched && form.controls.name.invalid">
-            Name is required (min 2 chars)
-          </mat-error>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" class="w-full">
-          <mat-label>Revenue</mat-label>
-          <input matInput type="number" formControlName="revenue" />
-          <mat-error *ngIf="form.controls.revenue.touched && form.controls.revenue.invalid">
-            Revenue must be a positive number
-          </mat-error>
+          @if (form.controls.name.touched && form.controls.name.invalid) {
+            <mat-error>
+              Name is required (min 2 chars)
+            </mat-error>
+          }
         </mat-form-field>
       </mat-card-content>
     </mat-card>
@@ -83,19 +88,30 @@
         <mat-card-title class="text-base">Courts</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <div class="w-full">
-          <div class="text-xs text-gray-600 mb-1">Courts</div>
-          <p class="text-sm text-gray-800 break-words">
-            {{ form.get('courts')?.value || '—' }}
-          </p>
-        </div>
+        <mat-form-field appearance="outline" class="w-full">
+          <mat-label>Courts (comma separated numbers)</mat-label>
+          <input matInput formControlName="courts" placeholder="1, 2, 3" />
+        </mat-form-field>
       </mat-card-content>
     </mat-card>
 
     <div class="flex items-center gap-3">
-      <mat-progress-spinner *ngIf="saving()" mode="indeterminate" diameter="20"></mat-progress-spinner>
-      <span *ngIf="saving()" class="text-sm text-gray-600">Saving…</span>
+      @if (saving()) {
+        <mat-progress-spinner mode="indeterminate" diameter="20"></mat-progress-spinner>
+        <span class="text-sm text-gray-600">Saving…</span>
+      }
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button mat-raised-button color="primary" type="submit" [disabled]="saving()">
+        <mat-icon>save</mat-icon>
+        Save
+      </button>
+      <button mat-stroked-button type="button" (click)="cancelEdit()" [disabled]="saving()">
+        <mat-icon>close</mat-icon>
+        Cancel
+      </button>
     </div>
   </form>
-</ng-template>
+}
 

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details-tab/site-details-tab.component.ts
@@ -88,8 +88,9 @@ export class SiteDetailsTabComponent {
     }
 
     const closedDays = this.splitCsv(this.form.controls.closedDays.value)
-      .map(s => s)
-      .filter(s => s.length > 0);
+      .map(value => new Date(value))
+      .filter(date => !Number.isNaN(date.getTime()))
+      .map(date => date.toISOString());
 
     const courts = this.splitCsv(this.form.controls.courts.value)
       .map(courtNum => ({

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.html
@@ -16,11 +16,8 @@
       <div class="p-4 flex flex-col gap-4 max-w-3xl mx-auto">
         <app-site-details-tab
           [site]="site"
-          [editMode]="editMode()"
           [saving]="saving()"
-          (startEdit)="startEdit()"
-          (cancelEdit)="cancelEdit()"
-          (save)="onDetailsSave($event)"
+          (saveSite)="onDetailsSave($event)"
         />
       </div>
     </mat-tab>

--- a/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/site-details/components/site-details/site-details.ts
@@ -44,7 +44,6 @@ export class SiteDetails {
 
   readonly loading = signal(true);
   readonly saving = signal(false);
-  readonly editMode = signal(false);
 
   readonly id$ = this.route.paramMap.pipe(
     map(pm => pm.get('id')),
@@ -76,27 +75,13 @@ export class SiteDetails {
     await this.router.navigate(['/sites']);
   }
 
-  startEdit(): void {
-    this.editMode.set(true);
-  }
-
-  cancelEdit(): void {
-    this.editMode.set(false);
-  }
-
-  onDetailsSave(data: { name: string; closedDays: Date[] }): void {
+  onDetailsSave(data: UpdateSiteRequest): void {
     this.site$.pipe(
       take(1),
       switchMap(site => {
         if (!site) {
           return of(null);
         }
-
-        const updated: UpdateSiteRequest = {
-          name: data.name,
-          closedDays: data.closedDays.map(d => d.toISOString()),
-          courts: site.courts.map(c => ({ number: c.number }))
-        };
 
         this.saving.set(true);
         return this.id$.pipe(
@@ -106,13 +91,12 @@ export class SiteDetails {
               this.saving.set(false);
               return of(null);
             }
-            return this.siteService.update(id, updated);
+            return this.siteService.update(id, data);
           })
         );
       }),
       tap(() => {
         this.saving.set(false);
-        this.editMode.set(false);
       }),
       catchError(err => {
         console.error('Failed to save site', err);

--- a/SiteManagement.API/DAL/Configurations/CourtConfiguration.cs
+++ b/SiteManagement.API/DAL/Configurations/CourtConfiguration.cs
@@ -21,7 +21,7 @@ public class CourtConfiguration : IEntityTypeConfiguration<Court>
         builder.HasMany(c => c.TimeSlots)
             .WithOne(ts => ts.Court)
             .HasForeignKey(ts => ts.CourtId)
-            .OnDelete(DeleteBehavior.Restrict);  // Prevent cascade conflicts
+            .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(c => new { c.SiteId, c.Number })
             .IsUnique();


### PR DESCRIPTION
- Refactored site details tab to use Angular's new @if/@for syntax.
- Moved edit mode logic inside the component using signals.
- Made "courts" editable; removed "revenue" from edit form.
- Updated form validation, error handling, and UI actions.
- Changed save output to emit UpdateSiteRequest (name, closedDays, courts).
- Parent no longer manages edit state; only handles saveSite event.
- Backend: Court TimeSlots now cascade delete;
- Disabled Angular CLI analytics in project config.