### PR TITLE
163 fix bug db migration duplicate rows in scedule

### DIFF
--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.html
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.html
@@ -12,12 +12,12 @@
   <tbody>
     @if (days.length > 0) {
       @for (slotIndex of slotIndices; track slotIndex) {
-        <tr class="border-b border-gray-200 hover:bg-gray-50">
+        <tr class="border-b border-gray-200">
           <td class="p-2 md:p-3 text-center font-medium bg-gray-50 border-r-2 border-blue-700 min-w-[60px] md:min-w-[80px] whitespace-nowrap">
             <div class="text-[11px] md:text-sm text-gray-800">{{ getTimeForSlotIndex(days[0], slotIndex) }}</div>
           </td>
           @for (day of days; track getDateKey(day)) {
-            <td class="p-1 md:p-2 border-r border-gray-300 last:border-r-0 min-w-0 md:min-w-[150px] align-middle">
+            <td class="p-1 md:p-2 border-r border-gray-300 last:border-r-0 min-w-0 md:min-w-[150px] align-middle hover:bg-gray-50">
               @if (getTimeSlotForIndex(day, slotIndex); as timeSlot) {
                 <button
                   [class.available]="timeSlot.displayState === SlotDisplayState.Available"
@@ -32,6 +32,9 @@
                 >
                   <span class="block">{{ timeSlot.startTime }}</span>
                   <span class="block">{{ timeSlot.endTime }}</span>
+                  @if (timeSlot.displayState === SlotDisplayState.Available) {
+                    <span class="block opacity-75">{{ timeSlot.availableCourtCount }}/{{ timeSlot.totalCourtCount }}</span>
+                  }
                 </button>
               }
             </td>

--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.ts
@@ -4,11 +4,12 @@ import { MatButtonModule } from '@angular/material/button';
 import { format } from 'date-fns';
 import {
   DaySchedule,
+  ConsolidatedTimeSlot,
   TimeSlotUI,
   SlotDisplayState,
-  mapToSlotDisplayState,
   getSlotDisplayStateName
 } from '../../models';
+import { BookState } from '../../../../../core/api/site';
 
 @Component({
   selector: 'app-schedule-table',
@@ -36,18 +37,15 @@ export class ScheduleTableComponent implements OnChanges {
     this.slotCache.clear();
     for (const day of this.days ?? []) {
       const dateKey = format(day.date, 'yyyy-MM-dd');
-      this.slotCache.set(dateKey, this.getTimeSlotUIData(day));
+      this.slotCache.set(dateKey, this.buildTimeSlotUIList(day));
     }
   }
 
   getTimeForSlotIndex(day: DaySchedule, slotIndex: number): string {
     if (!day.slots || day.slots.length === 0) return '';
-
     const slot = day.slots[slotIndex];
     if (!slot) return '';
-
-    const date = new Date(slot.dateTime);
-    return format(date, 'HH:mm');
+    return format(new Date(slot.dateTime), 'HH:mm');
   }
 
   getTimeSlotForIndex(day: DaySchedule, slotIndex: number): TimeSlotUI | null {
@@ -56,32 +54,70 @@ export class ScheduleTableComponent implements OnChanges {
     return slots?.[slotIndex] ?? null;
   }
 
-  getTimeSlotUIData(day: DaySchedule): TimeSlotUI[] {
+  getDateKey(day: DaySchedule): string {
+    return format(day.date, 'yyyy-MM-dd');
+  }
+
+  /**
+   * Build the UI slot list for a single day from its consolidated slots.
+   * One TimeSlotUI is produced per ConsolidatedTimeSlot (i.e. per unique slot number).
+   * The displayState is Available when at least one court is free.
+   */
+  private buildTimeSlotUIList(day: DaySchedule): TimeSlotUI[] {
     if (!day.slots || day.slots.length === 0) {
       return [];
     }
 
-    // Sort slots by datetime
-    const sortedSlots = [...day.slots].sort((a, b) =>
-      new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime()
-    );
-
-    // Transform each slot into TimeSlotUI
-    return sortedSlots.map((slot, index) => {
+    return day.slots.map((slot: ConsolidatedTimeSlot, index: number) => {
       const startDate = new Date(slot.dateTime);
       const endDate = new Date(startDate.getTime() + this.slotDurationMinutes * 60000);
+
+      const isAvailable = slot.availableCourtCount > 0;
+      const displayState = isAvailable
+        ? SlotDisplayState.Available
+        : this.dominantBookedState(slot);
 
       return {
         number: index + 1,
         startTime: format(startDate, 'HH:mm'),
         endTime: format(endDate, 'HH:mm'),
-        displayState: mapToSlotDisplayState(slot.bookState)
+        displayState,
+        availableCourtCount: slot.availableCourtCount,
+        totalCourtCount: slot.totalCourtCount
       };
     });
   }
 
-  getDateKey(day: DaySchedule): string {
-    return format(day.date, 'yyyy-MM-dd');
+  /**
+   * Return the most "advanced" booked state among all courts for display purposes.
+   * Priority: Played > Paid > Booked > BookInProgress
+   */
+  private dominantBookedState(slot: ConsolidatedTimeSlot): SlotDisplayState {
+    const priority: Record<BookState, number> = {
+      [BookState.Played]: 4,
+      [BookState.Paid]: 3,
+      [BookState.Booked]: 2,
+      [BookState.BookInProgress]: 1
+    };
+
+    let dominant = SlotDisplayState.BookInProgress;
+    let maxPriority = 0;
+
+    for (const courtSlot of slot.courtSlots) {
+      if (courtSlot.bookState) {
+        const p = priority[courtSlot.bookState] ?? 0;
+        if (p > maxPriority) {
+          maxPriority = p;
+          switch (courtSlot.bookState) {
+            case BookState.Played: dominant = SlotDisplayState.Played; break;
+            case BookState.Paid: dominant = SlotDisplayState.Paid; break;
+            case BookState.Booked: dominant = SlotDisplayState.Booked; break;
+            default: dominant = SlotDisplayState.BookInProgress;
+          }
+        }
+      }
+    }
+    return dominant;
   }
 
   protected readonly SlotDisplayState = SlotDisplayState;

--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/components/weekly-planner/weekly-planner.component.css
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/components/weekly-planner/weekly-planner.component.css
@@ -200,10 +200,6 @@
   border-bottom: 1px solid #e0e0e0;
 }
 
-.slot-row-mobile:hover {
-  background-color: #f5f5f5;
-}
-
 /* Mobile time column */
 .time-cell-mobile {
   padding: 8px;

--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/models/day-schedule.model.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/models/day-schedule.model.ts
@@ -1,12 +1,31 @@
 import { TimeSlotResponse } from '../../../../core/api/site';
 
 /**
- * Represents a day's schedule with all time slots for that day.
- * This is the primary data structure used throughout the schedule feature.
+ * A consolidated time slot that merges all courts for a given slot number/time.
+ * A single row is shown in the schedule table regardless of how many courts exist.
+ * The slot is considered available when at least one court is available.
+ */
+export interface ConsolidatedTimeSlot {
+  /** ISO slot number shared by all courts at this time */
+  timeSlotNumber: number;
+  /** The datetime of this slot (same across courts) */
+  dateTime: string;
+  /** Number of courts that are available for this slot */
+  availableCourtCount: number;
+  /** Total number of courts for this slot */
+  totalCourtCount: number;
+  /** Raw per-court slots – kept for booking purposes */
+  courtSlots: TimeSlotResponse[];
+}
+
+/**
+ * Represents a day's schedule with consolidated time slots.
+ * Each entry in `slots` represents one time-slot row (merged across all courts).
  */
 export interface DaySchedule {
   date: Date;
   dayName: string;
-  slots: TimeSlotResponse[];
+  /** One entry per unique time slot number – courts are consolidated. */
+  slots: ConsolidatedTimeSlot[];
 }
 

--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/models/time-slot-ui.model.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/models/time-slot-ui.model.ts
@@ -1,13 +1,18 @@
 import { SlotDisplayState } from './slot-display-state.model';
 
 /**
- * UI representation of a time slot with computed display properties.
- * Used for rendering time slots in the schedule table.
+ * UI representation of a consolidated time slot with computed display properties.
+ * One entry represents a single row in the schedule table (all courts merged).
  */
 export interface TimeSlotUI {
   number: number;
   startTime: string;
   endTime: string;
+  /** Available if at least one court is free, otherwise reflects the dominant booked state. */
   displayState: SlotDisplayState;
+  /** Number of courts available for this slot. */
+  availableCourtCount: number;
+  /** Total number of courts for this slot. */
+  totalCourtCount: number;
 }
 

--- a/ProjetWeb.Frontend/src/app/views/pages/schedule/services/schedule.service.ts
+++ b/ProjetWeb.Frontend/src/app/views/pages/schedule/services/schedule.service.ts
@@ -5,7 +5,7 @@ import { SiteFacadeService } from '../../../../core/services/site-facade.service
 import { TimeSlotResponse } from '../../../../core/api/site';
 import { SiteResponse } from '../../../../core/api/site/model/model-override';
 import { format } from 'date-fns';
-import { DaySchedule } from '../models';
+import { ConsolidatedTimeSlot, DaySchedule } from '../models';
 
 /**
  * Service for managing schedule-related operations.
@@ -26,7 +26,8 @@ export class ScheduleService {
   }
 
   /**
-   * Get schedule organized by day for a specific site and week.
+   * Get schedule organised by day for a specific site and week.
+   * Multiple courts for the same slot number are consolidated into a single row.
    * @param siteId - The ID of the site
    * @param weekNumber - The ISO week number to fetch (optional)
    * @param numberOfWeeks - The number of weeks to fetch (optional, defaults to 1)
@@ -39,7 +40,11 @@ export class ScheduleService {
   }
 
   /**
-   * Transform flat TimeSlotResponse array into day-based structure.
+   * Transform flat TimeSlotResponse array into day-based structure with consolidated slots.
+   * Slots sharing the same date and timeSlotNumber (i.e. different courts) are merged
+   * into a single ConsolidatedTimeSlot.  A merged slot is Available when at least one
+   * of its court slots has no booking (bookState is absent / falsy).
+   *
    * @param timeSlots - Array of time slot responses
    * @returns Array of day schedules sorted by date
    */
@@ -48,27 +53,48 @@ export class ScheduleService {
       return [];
     }
 
-    // Group time slots by date
+    // ── Group raw slots by calendar date ──────────────────────────────────────
     const slotsByDate = new Map<string, TimeSlotResponse[]>();
 
     for (const slot of timeSlots) {
-      const date = new Date(slot.dateTime);
-      const dateKey = format(date, 'yyyy-MM-dd');
-
+      const dateKey = format(new Date(slot.dateTime), 'yyyy-MM-dd');
       if (!slotsByDate.has(dateKey)) {
         slotsByDate.set(dateKey, []);
       }
       slotsByDate.get(dateKey)!.push(slot);
     }
 
-    // Convert to DaySchedule array and sort by date
+    // ── For each day, consolidate per timeSlotNumber ──────────────────────────
     return Array.from(slotsByDate.entries())
-      .map(([dateKey, slots]) => {
-        const date = new Date(slots[0].dateTime);
+      .map(([, daySlots]) => {
+        const date = new Date(daySlots[0].dateTime);
+
+        // Group by timeSlotNumber
+        const bySlotNumber = new Map<number, TimeSlotResponse[]>();
+        for (const slot of daySlots) {
+          if (!bySlotNumber.has(slot.timeSlotNumber)) {
+            bySlotNumber.set(slot.timeSlotNumber, []);
+          }
+          bySlotNumber.get(slot.timeSlotNumber)!.push(slot);
+        }
+
+        const consolidated: ConsolidatedTimeSlot[] = Array.from(bySlotNumber.entries())
+          .map(([slotNumber, courtSlots]) => {
+            const availableCourtCount = courtSlots.filter(s => !s.bookState).length;
+            return {
+              timeSlotNumber: slotNumber,
+              dateTime: courtSlots[0].dateTime,
+              availableCourtCount,
+              totalCourtCount: courtSlots.length,
+              courtSlots
+            };
+          })
+          .sort((a, b) => a.timeSlotNumber - b.timeSlotNumber);
+
         return {
           date,
           dayName: format(date, 'EEEE'),
-          slots: slots.sort((a, b) => new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime())
+          slots: consolidated
         };
       })
       .sort((a, b) => a.date.getTime() - b.date.getTime());

--- a/SiteManagement.MigrationService/DataSeedWorker.cs
+++ b/SiteManagement.MigrationService/DataSeedWorker.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Retry;
 using SiteManagement.API.DAL;
@@ -8,6 +9,7 @@ namespace SiteManagement.MigrationService;
 public class DataSeedWorker(
     IServiceProvider serviceProvider,
     IHostApplicationLifetime lifetime,
+    IOptions<SeedingOptions> seedingOptions,
     ILogger<DataSeedWorker> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -36,6 +38,13 @@ public class DataSeedWorker(
 
             try
             {
+                var forceRecreate = seedingOptions.Value.ForceRecreate;
+
+                if (forceRecreate)
+                {
+                    logger.LogWarning("ForceRecreate is enabled - dropping and recreating database...");
+                    await dbContext.Database.EnsureDeletedAsync(token);
+                }
                 await dbContext.Database.MigrateAsync(token);
             }
             catch (Exception ex)

--- a/SiteManagement.MigrationService/DataSeeder.cs
+++ b/SiteManagement.MigrationService/DataSeeder.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using SiteManagement.API.DAL;
 using SiteManagement.API.DAL.Entities;
 
@@ -7,20 +6,10 @@ namespace SiteManagement.MigrationService;
 
 public class DataSeeder(
     SiteManagementDbContext context,
-    ILogger<DataSeeder> logger,
-    IOptions<SeedingOptions> seedingOptions)
+    ILogger<DataSeeder> logger)
 {
     public async Task SeedAsync(CancellationToken cancellationToken = default)
     {
-        var forceRecreate = seedingOptions.Value.ForceRecreate;
-
-        if (forceRecreate)
-        {
-            logger.LogWarning("ForceRecreate is enabled - dropping and recreating database...");
-            await context.Database.EnsureDeletedAsync(cancellationToken);
-            await context.Database.MigrateAsync(cancellationToken);
-        }
-
         if (await context.Sites.AnyAsync(cancellationToken))
         {
             logger.LogInformation("Database already contains data. Skipping seeding.");


### PR DESCRIPTION
This pull request introduces a major refactor of the schedule table feature to consolidate per-court time slots into single rows per time slot, and improves the display of court availability. The changes also update the data seeding process in the migration service to allow for forced database recreation via configuration.

**Schedule Table Refactor and UI Improvements**

* Added the `ConsolidatedTimeSlot` model, which merges all courts for a given slot number/time into one entry, simplifying the schedule table and making it easier to see overall availability. (`ProjetWeb.Frontend/src/app/views/pages/schedule/models/day-schedule.model.ts`)
* Updated the `ScheduleService` to consolidate slots by timeSlotNumber for each day, so the schedule table now shows one row per slot with total and available court counts. (`ProjetWeb.Frontend/src/app/views/pages/schedule/services/schedule.service.ts`) [[1]](diffhunk://#diff-249f20aa87238ea68262e6cf6c0574589b0d7b832e43d0fbca1adc9b70e28203L8-R8) [[2]](diffhunk://#diff-249f20aa87238ea68262e6cf6c0574589b0d7b832e43d0fbca1adc9b70e28203L29-R30) [[3]](diffhunk://#diff-249f20aa87238ea68262e6cf6c0574589b0d7b832e43d0fbca1adc9b70e28203L42-R47) [[4]](diffhunk://#diff-249f20aa87238ea68262e6cf6c0574589b0d7b832e43d0fbca1adc9b70e28203L51-R97)
* Refactored `TimeSlotUI` and `ScheduleTableComponent` to support consolidated slots, display available/total court counts, and show the dominant booking state when no courts are available. (`ProjetWeb.Frontend/src/app/views/pages/schedule/models/time-slot-ui.model.ts`, `ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.ts`) [[1]](diffhunk://#diff-f5725f5fd9bd07bc386b5f319c08520e388cdf451a63c2218c428481d3ede078L4-R16) [[2]](diffhunk://#diff-96f38bc5464e534fe030e9fbd0ce0218edaccbe49f390713a5810ca1b035b369R7-R12) [[3]](diffhunk://#diff-96f38bc5464e534fe030e9fbd0ce0218edaccbe49f390713a5810ca1b035b369L39-R48) [[4]](diffhunk://#diff-96f38bc5464e534fe030e9fbd0ce0218edaccbe49f390713a5810ca1b035b369L59-R120)
* Updated the schedule table UI to display available court counts for available slots, and removed redundant hover styling from mobile rows. (`ProjetWeb.Frontend/src/app/views/pages/schedule/components/schedule-table/schedule-table.component.html`, `ProjetWeb.Frontend/src/app/views/pages/schedule/components/weekly-planner/weekly-planner.component.css`) [[1]](diffhunk://#diff-07d67c4a9216224f5136dc99c3b5c28925762244ef15d2a40dcfc9595f21997fL15-R20) [[2]](diffhunk://#diff-07d67c4a9216224f5136dc99c3b5c28925762244ef15d2a40dcfc9595f21997fR35-R37) [[3]](diffhunk://#diff-0396e68c5b35004ac163b8dfae458b5b5e1fe052a4fe683b1dd67063470cb89bL203-L206)

**Migration Service Enhancement**

* Changed the `DataSeedWorker` to support a `ForceRecreate` option via `SeedingOptions`, allowing the database to be dropped and recreated before migration if configured. (`SiteManagement.MigrationService/DataSeedWorker.cs`) [[1]](diffhunk://#diff-62e52ac86e38cd542008ab00a244b0a0d35556192d951519ce318a591f236550R2) [[2]](diffhunk://#diff-62e52ac86e38cd542008ab00a244b0a0d35556192d951519ce318a591f236550R12) [[3]](diffhunk://#diff-62e52ac86e38cd542008ab00a244b0a0d35556192d951519ce318a591f236550R41-R47)
* Simplified the `DataSeeder` class to remove redundant force recreate logic, as this is now handled in `DataSeedWorker`. (`SiteManagement.MigrationService/DataSeeder.cs`)

These improvements make the schedule table more user-friendly and informative, and provide greater flexibility for database management during development and deployment.